### PR TITLE
Add summary cards section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { StatsSection } from "@/components/StatsSection";
 
 export default function Home() {
   return (
@@ -24,6 +25,8 @@ export default function Home() {
             Save and see your changes instantly.
           </li>
         </ol>
+
+        <StatsSection />
 
         <div className="flex gap-4 items-center flex-col sm:flex-row">
           <a

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -1,0 +1,22 @@
+export type StatsCardProps = {
+  title: string
+  value: string
+  description?: string
+}
+
+export function StatsCard({ title, value, description }: StatsCardProps) {
+  return (
+    <article
+      className="rounded-xl bg-white dark:bg-neutral-900 shadow-md p-6 hover:shadow-lg focus-within:ring-2 focus-within:ring-blue-500 transition"
+      tabIndex={0}
+      role="group"
+      aria-label={title}
+    >
+      <p className="text-sm text-gray-500 dark:text-gray-400">{title}</p>
+      <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">{value}</p>
+      {description && (
+        <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">{description}</p>
+      )}
+    </article>
+  )
+}

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,0 +1,22 @@
+import { StatsCard } from "./StatsCard"
+
+const stats = [
+  { title: "프로젝트 수", value: "8" },
+  { title: "사용 기술 수", value: "12" },
+  { title: "공부 시간", value: "350h+" },
+]
+
+export function StatsSection() {
+  return (
+    <section aria-labelledby="stats-heading" className="mt-12 w-full">
+      <h2 id="stats-heading" className="sr-only">
+        요약 통계 정보
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {stats.map((stat, i) => (
+          <StatsCard key={i} {...stat} />
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- create `StatsCard` and `StatsSection` components
- render summary cards on the home page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843b252c21c832ab2ce206ef157e0c9