### PR TITLE
Add summary cards section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import Image from "next/image";
+import { StatsSection } from "@/components/StatsSection";
+import { HeroSection } from "@/components/HeroSection";
 
 export default function Home() {
   return (
@@ -24,6 +26,10 @@ export default function Home() {
             Save and see your changes instantly.
           </li>
         </ol>
+
+        <HeroSection />
+
+        <StatsSection />
 
         <div className="flex gap-4 items-center flex-col sm:flex-row">
           <a

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,31 @@
+export function HeroSection() {
+  return (
+    <section
+      className="w-full max-w-3xl mx-auto text-center sm:text-left py-24"
+      aria-labelledby="hero-heading"
+    >
+      <h1 id="hero-heading" className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white">
+        안녕하세요, 저는 김세일입니다
+      </h1>
+      <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
+        사람을 위한 UI를 고민하는 프론트엔드 개발자입니다. 좋은 인터페이스는 감동을 남깁니다.
+      </p>
+      <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center sm:justify-start">
+        <a
+          href="#projects"
+          className="bg-black text-white dark:bg-white dark:text-black px-6 py-3 rounded-lg font-semibold hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors focus-visible:outline focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label="프로젝트 목록 보기"
+        >
+          프로젝트 보기
+        </a>
+        <a
+          href="/resume.pdf"
+          className="border border-gray-300 dark:border-gray-600 px-6 py-3 rounded-lg font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus-visible:outline focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label="이력서 다운로드"
+        >
+          이력서 다운로드
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -1,0 +1,22 @@
+export type StatsCardProps = {
+  title: string
+  value: string
+  description?: string
+}
+
+export function StatsCard({ title, value, description }: StatsCardProps) {
+  return (
+    <article
+      className="rounded-xl bg-white dark:bg-neutral-900 shadow-md p-6 hover:shadow-lg focus-within:ring-2 focus-within:ring-blue-500 transition"
+      tabIndex={0}
+      role="group"
+      aria-label={title}
+    >
+      <p className="text-sm text-gray-500 dark:text-gray-400">{title}</p>
+      <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">{value}</p>
+      {description && (
+        <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">{description}</p>
+      )}
+    </article>
+  )
+}

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,0 +1,22 @@
+import { StatsCard } from "./StatsCard"
+
+const stats = [
+  { title: "프로젝트 수", value: "8" },
+  { title: "사용 기술 수", value: "12" },
+  { title: "공부 시간", value: "350h+" },
+]
+
+export function StatsSection() {
+  return (
+    <section aria-labelledby="stats-heading" className="mt-12 w-full">
+      <h2 id="stats-heading" className="sr-only">
+        요약 통계 정보
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {stats.map((stat, i) => (
+          <StatsCard key={i} {...stat} />
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- create `StatsCard` and `StatsSection` components
- render summary cards on the home page
- add `HeroSection` for portfolio intro

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843b252c21c832ab2ce206ef157e0c9