### PR TITLE
Add custom 404 and contact page

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,23 @@
+export const metadata = {
+  title: "Contact",
+};
+
+export default function ContactPage() {
+  return (
+    <main className="mx-auto w-full max-w-5xl p-8 sm:p-20">
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-white">연락처</h1>
+      <p className="mt-2 text-gray-600 dark:text-gray-400">아래 정보로 언제든지 연락해주세요.</p>
+      <section className="mt-8 space-y-4" aria-labelledby="contact-heading">
+        <h2 id="contact-heading" className="sr-only">
+          Contact Info
+        </h2>
+        <p className="text-lg text-gray-700 dark:text-gray-300">
+          이메일: <a href="mailto:hello@example.com" className="text-blue-600 dark:text-blue-400 hover:underline">hello@example.com</a>
+        </p>
+        <p className="text-lg text-gray-700 dark:text-gray-300">
+          GitHub: <a href="https://github.com/username" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">github.com/username</a>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col items-center justify-center p-8 text-center">
+      <h1 className="text-4xl font-bold text-gray-900 dark:text-white">페이지를 찾을 수 없습니다.</h1>
+      <p className="mt-4 text-gray-600 dark:text-gray-400">요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.</p>
+      <Link
+        href="/"
+        className="mt-8 text-blue-600 dark:text-blue-400 hover:underline focus-visible:outline focus-visible:ring-2 focus-visible:ring-blue-500"
+      >
+        홈으로 돌아가기
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- provide custom `src/app/not-found.tsx` to handle 404s
- add new Contact page at `src/app/contact/page.tsx`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845d9025944832a94711a1722347ee2