### PR TITLE
Update project page params signature

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -2,12 +2,12 @@ import { projects } from "@/data/projects";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 
-export default async function Page({
+export default function Page({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }) {
-  const { slug } = await params;
+  const { slug } = params;
   const project = projects.find((p) => p.slug === slug);
 
   if (!project) {


### PR DESCRIPTION
## Summary
- refactor project detail page to accept params directly

## Testing
- `npm run build` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: Module '"next"' has no exported member 'NextConfig')*


------
https://chatgpt.com/codex/tasks/task_e_6847553bea50832ab64c25898e3ad78e