### PR TITLE
Update dynamic project page with PageProps

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,13 +1,14 @@
 import { projects } from "@/data/projects";
 import Image from "next/image";
 import { notFound } from "next/navigation";
+import type { PageProps } from "next";
 
-export default function Page({
-  params,
-}: {
-  params: { slug: string };
-}) {
-  const { slug } = params;
+interface AsyncParamsPageProps extends Omit<PageProps<{ slug: string }>, "params"> {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function Page({ params }: AsyncParamsPageProps) {
+  const { slug } = await params;
   const project = projects.find((p) => p.slug === slug);
 
   if (!project) {


### PR DESCRIPTION
## Summary
- migrate dynamic project page to typed `PageProps`
- handle `params` as an async promise

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68477eb30714832a9ae9cae067fe4153