### PR TITLE
Implement blog feed and team info

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,3 +268,8 @@ myportfolio/
    - Google Analytics와 Vercel Analytics 통합
    - 프로젝트 이미지 lazy loading 적용
    - GitHub Actions 워크플로우로 lint · build 자동화
+2. 2025-06-11 (Codex) - 블로그 RSS 연동 및 데이터 구조 확장
+   - `/api/blog` 라우트에서 RSS 파싱 후 최신 글 제공
+   - 홈 페이지 `BlogSection` 컴포넌트로 최근 글 5개 표시
+   - 프로젝트 타입에 팀원(`team`)과 리뷰(`reviews`) 필드 추가
+   - 프로젝트 상세 페이지에 팀원 소개 및 외부 리뷰 섹션 노출

--- a/content/projects/meal-ai.md
+++ b/content/projects/meal-ai.md
@@ -21,6 +21,12 @@ learnings:
   - AI 추천 알고리즘 이해
   - FastAPI와 프론트엔드 통신 최적화
   - 사용자 피드백을 통한 반복 개선
+team:
+  - name: 김세일
+    role: Front-end
+    github: https://github.com/saeil
+reviews:
+  - https://example.com/review1
 ---
 
 개인 맞춤 식단 분석과 영양소 기반 레시피 추천을 제공하는 서비스입니다.

--- a/content/projects/portfolio-site.md
+++ b/content/projects/portfolio-site.md
@@ -21,6 +21,12 @@ learnings:
   - Next.js App Router 활용
   - Tailwind CSS 커스터마이징
   - 접근성 고려한 UI 구성
+team:
+  - name: 김세일
+    role: Full-stack
+    github: https://github.com/saeil
+reviews:
+  - https://example.com/review2
 ---
 
 다크 모드와 프로젝트 필터 기능을 갖춘 포트폴리오 사이트입니다.

--- a/content/projects/weather-app.md
+++ b/content/projects/weather-app.md
@@ -21,6 +21,12 @@ learnings:
   - Vue 컴포넌트 설계
   - API 요청 캐싱 전략
   - 반응형 차트 구현
+team:
+  - name: 김세일
+    role: Front-end
+    github: https://github.com/saeil
+reviews:
+  - https://example.com/review3
 ---
 
 실시간 날씨 조회와 주간 예보 그래프를 지원합니다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "remark": "^15.0.1",
-        "remark-html": "^16.0.1"
+        "remark-html": "^16.0.1",
+        "rss-parser": "^3.13.0",
+        "swr": "^2.3.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2856,6 +2858,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -6334,6 +6345,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6440,6 +6461,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -6941,6 +6968,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
@@ -7369,6 +7409,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -7510,6 +7559,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "remark": "^15.0.1",
-    "remark-html": "^16.0.1"
+    "remark-html": "^16.0.1",
+    "rss-parser": "^3.13.0",
+    "swr": "^2.3.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import Parser from 'rss-parser'
+
+export const dynamic = 'force-dynamic'
+
+const parser = new Parser()
+
+export async function GET() {
+  const feedUrl = process.env.BLOG_RSS_URL || 'https://hnrss.org/frontpage'
+  try {
+    const feed = await parser.parseURL(feedUrl)
+    const items = feed.items?.slice(0, 5).map(item => ({
+      title: item.title,
+      link: item.link,
+      pubDate: item.pubDate,
+    })) || []
+    return NextResponse.json({ items })
+  } catch {
+    return NextResponse.json({ items: [], error: 'Failed to load RSS' }, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { HeroSection } from "@/components/HeroSection";
 import { StatsSection } from "@/components/StatsSection";
 import { ProjectsSection } from "@/components/ProjectsSection";
+import { BlogSection } from "@/components/BlogSection";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -23,6 +24,7 @@ export default function Home() {
       <HeroSection />
       <StatsSection />
       <ProjectsSection />
+      <BlogSection />
     </main>
   );
 }

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -93,6 +93,69 @@ export default async function Page({
         </ul>
       </section>
 
+      {project.team?.length ? (
+        <section className="mt-8" aria-labelledby="team-heading">
+          <h2
+            id="team-heading"
+            className="text-2xl font-semibold text-gray-900 dark:text-white"
+          >
+            팀원 소개
+          </h2>
+          <ul className="mt-4 space-y-2">
+            {project.team.map((member, i) => (
+              <li key={i} className="text-gray-700 dark:text-gray-300">
+                {member.name} - {member.role}
+                {member.github && (
+                  <a
+                    href={member.github}
+                    className="ml-2 text-blue-600 dark:text-blue-400 hover:underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    GitHub
+                  </a>
+                )}
+                {member.linkedin && (
+                  <a
+                    href={member.linkedin}
+                    className="ml-2 text-blue-600 dark:text-blue-400 hover:underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    LinkedIn
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {project.reviews?.length ? (
+        <section className="mt-8" aria-labelledby="review-heading">
+          <h2
+            id="review-heading"
+            className="text-2xl font-semibold text-gray-900 dark:text-white"
+          >
+            외부 리뷰
+          </h2>
+          <ul className="mt-4 list-disc list-inside space-y-2">
+            {project.reviews.map((link, i) => (
+              <li key={i}>
+                <a
+                  href={link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  {link}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
       <section className="mt-8" aria-labelledby="learnings-heading">
         <h2
           id="learnings-heading"

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -67,6 +67,17 @@ export default async function ProjectsPage({
     case "contribution":
       projectList.sort((a, b) => b.contribution - a.contribution);
       break;
+    case "usage":
+      const freq: Record<string, number> = {};
+      projects.flatMap(p => p.stack).forEach(s => {
+        freq[s] = (freq[s] ?? 0) + 1;
+      });
+      projectList.sort((a, b) => {
+        const aScore = a.stack.reduce((sum, s) => sum + (freq[s] ?? 0), 0);
+        const bScore = b.stack.reduce((sum, s) => sum + (freq[s] ?? 0), 0);
+        return bScore - aScore;
+      });
+      break;
     default:
       break;
   }

--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -1,0 +1,42 @@
+'use client'
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+type Post = {
+  title: string
+  link: string
+  pubDate?: string
+}
+
+export function BlogSection() {
+  const { data, error } = useSWR<{ items: Post[] }>( '/api/blog', fetcher)
+
+  if (error) {
+    return <p className="mt-4 text-red-500">블로그 글을 불러오지 못했습니다.</p>
+  }
+  const posts = data?.items ?? []
+  return (
+    <section className="w-full mt-12" aria-labelledby="blog-heading">
+      <h2 id="blog-heading" className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
+        최신 글
+      </h2>
+      {posts.length === 0 ? (
+        <p className="text-gray-500 dark:text-gray-400">게시글이 없습니다.</p>
+      ) : (
+        <ul className="space-y-2">
+          {posts.map((post, i) => (
+            <li key={i} className="rounded-md p-4 bg-gray-50 dark:bg-neutral-800 hover:bg-gray-100 dark:hover:bg-neutral-700 transition">
+              <a href={post.link} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 dark:text-blue-400 hover:underline">
+                {post.title}
+              </a>
+              {post.pubDate && (
+                <span className="block text-xs text-gray-400 mt-1">{post.pubDate}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/src/components/ProjectFilterBar.tsx
+++ b/src/components/ProjectFilterBar.tsx
@@ -103,6 +103,7 @@ export function ProjectFilterBar({
           <option value="oldest">오래된순</option>
           <option value="name">이름순</option>
           <option value="contribution">기여도순</option>
+          <option value="usage">사용 빈도순</option>
         </select>
       </label>
 

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -14,5 +14,14 @@ export interface Project {
   };
   features: string[];
   learnings: string[];
+  team?: TeamMember[];
+  reviews?: string[];
   contentHtml?: string;
+}
+
+export interface TeamMember {
+  name: string;
+  role: string;
+  github?: string;
+  linkedin?: string;
 }

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -30,6 +30,8 @@ export async function getProjects(): Promise<Project[]> {
       links: data.links,
       features: data.features || [],
       learnings: data.learnings || [],
+      team: data.team || [],
+      reviews: data.reviews || [],
       contentHtml: htmlContent,
     });
   }


### PR DESCRIPTION
## Summary
- create `/api/blog` route parsing RSS feed
- render blog section on home with `BlogSection`
- extend `Project` type with `team` and `reviews`
- show team and review data on project pages
- allow usage-based project sorting
- document changes in Patch Notes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848d0f224a0832a9852ffc591db1eef