### PR TITLE
Fix next/image CDN config

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,3 +277,8 @@ myportfolio/
    - `LoadingProvider` 컨텍스트 도입으로 페이지 전환과 폼 제출 시 상단 로딩 바 표시
    - 이력서 다운로드 링크 클릭 시 토스트 알림 제공
    - 기존 `ProgressBar` 컴포넌트 삭제 및 레이아웃 구조 정리
+
+## Changelog
+
+- 외부 CDN 이미지 사용 시 next/image `Invalid src prop` 오류 수정  
+  (next.config.js `images.domains`에 `cdn.example.com` 추가)

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,11 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ["raw.githubusercontent.com", "images.unsplash.com"],
+    domains: [
+      "raw.githubusercontent.com",
+      "images.unsplash.com",
+      "cdn.example.com",
+    ],
   },
   env: {
     NEXT_PUBLIC_EMAILJS_SERVICE_ID: process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID,


### PR DESCRIPTION
## Summary
- allow `cdn.example.com` images in `next.config.ts`
- document fix in Changelog

## Testing
- `npm run dev` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ea3b8d94832a84ff96411d5e93a0