### PR TITLE
Add ContactForm tests

### DIFF
--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ContactForm } from '../ContactForm';
+import emailjs from 'emailjs-com';
+
+const startMock = jest.fn();
+const doneMock = jest.fn();
+const showMock = jest.fn();
+
+jest.mock('../Providers', () => ({
+  useToast: () => ({ show: showMock }),
+}));
+
+jest.mock('../LoadingProvider', () => ({
+  useLoading: () => ({ start: startMock, done: doneMock }),
+}));
+
+jest.mock('emailjs-com', () => ({
+  send: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ContactForm', () => {
+  it('shows validation errors when required fields are missing', async () => {
+    render(<ContactForm />);
+
+    fireEvent.submit(screen.getByRole('form', { name: 'Contact Form' }));
+
+    expect(await screen.findByText('이름을 입력해주세요')).toBeInTheDocument();
+    expect(screen.getByText('이메일을 입력해주세요')).toBeInTheDocument();
+    expect(screen.getByText('메시지를 입력해주세요')).toBeInTheDocument();
+    expect(emailjs.send).not.toHaveBeenCalled();
+  });
+
+  it('calls emailjs and shows success toast on valid submit', async () => {
+    (emailjs.send as jest.Mock).mockResolvedValue({});
+
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: 'John Doe' },
+    });
+    fireEvent.change(screen.getByLabelText('이메일'), {
+      target: { value: 'john@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('메시지'), {
+      target: { value: 'Hello' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '보내기' }));
+
+    await waitFor(() => expect(emailjs.send).toHaveBeenCalled());
+    expect(showMock).toHaveBeenCalledWith('메시지가 전송되었습니다!', 'success');
+    expect(startMock).toHaveBeenCalled();
+    expect(doneMock).toHaveBeenCalled();
+  });
+
+  it('shows error toast when emailjs fails', async () => {
+    (emailjs.send as jest.Mock).mockRejectedValue(new Error('fail'));
+
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: 'John Doe' },
+    });
+    fireEvent.change(screen.getByLabelText('이메일'), {
+      target: { value: 'john@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('메시지'), {
+      target: { value: 'Hello' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '보내기' }));
+
+    await waitFor(() => expect(emailjs.send).toHaveBeenCalled());
+    expect(showMock).toHaveBeenCalledWith('전송 중 오류가 발생했습니다.', 'error');
+    expect(startMock).toHaveBeenCalled();
+    expect(doneMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `ContactForm` covering validation, success, and failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68493bb7a604832a97c762637aa27485