### PR TITLE
Remove embedded font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 
 # resume
 public/resume.pdf
+public/fonts/

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "myportfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@pdf-lib/fontkit": "^1.1.1",
         "@vercel/analytics": "^1.5.0",
         "@vercel/og": "^0.6.8",
         "emailjs-com": "^3.2.0",
@@ -2483,6 +2484,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pdf-lib/fontkit": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/fontkit/-/fontkit-1.1.1.tgz",
+      "integrity": "sha512-KjMd7grNapIWS/Dm0gvfHEilSyAmeLvrEGVcqLGi0VYebuqqzTbgF29efCx7tvx+IEbG3zQciRSWl3GkUSvjZg==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
       }
     },
     "node_modules/@pdf-lib/standard-fonts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prebuild": "npm run generate:resume"
   },
   "dependencies": {
+    "@pdf-lib/fontkit": "^1.1.1",
     "@vercel/analytics": "^1.5.0",
     "@vercel/og": "^0.6.8",
     "emailjs-com": "^3.2.0",
@@ -42,7 +43,7 @@
     "jest-environment-jsdom": "^30.0.0",
     "tailwindcss": "^4",
     "ts-jest": "^29.1.1",
-    "typescript": "^5",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "typescript": "^5"
   }
 }

--- a/scripts/generateResume.ts
+++ b/scripts/generateResume.ts
@@ -1,7 +1,8 @@
 import fs from 'fs/promises'
 import path from 'path'
 import matter from 'gray-matter'
-import { PDFDocument, StandardFonts } from 'pdf-lib'
+import { PDFDocument } from 'pdf-lib'
+import fontkit from '@pdf-lib/fontkit'
 
 interface ProjectFrontmatter {
   title: string
@@ -27,7 +28,23 @@ async function loadProjects(): Promise<ProjectFrontmatter[]> {
 async function generate() {
   const projects = await loadProjects()
   const doc = await PDFDocument.create()
-  const font = await doc.embedFont(StandardFonts.Helvetica)
+  doc.registerFontkit(fontkit)
+  const fontPath = path.join(__dirname, '../public/fonts/NotoSansKR-Regular.otf')
+  let fontBytes: Uint8Array
+  try {
+    fontBytes = await fs.readFile(fontPath)
+  } catch {
+    console.log('Font not found locally. Downloading...')
+    const res = await fetch(
+      'https://raw.githubusercontent.com/notofonts/noto-cjk/main/Sans/OTF/Korean/NotoSansCJKkr-Regular.otf'
+    )
+    if (!res.ok) throw new Error('Failed to download font')
+    const arrayBuf = await res.arrayBuffer()
+    fontBytes = new Uint8Array(arrayBuf)
+    await fs.mkdir(path.dirname(fontPath), { recursive: true })
+    await fs.writeFile(fontPath, fontBytes)
+  }
+  const font = await doc.embedFont(fontBytes)
   let page = doc.addPage([595, 842])
   let y = 800
   page.drawText('Resume Projects Overview', { x: 50, y, size: 20, font })


### PR DESCRIPTION
## Summary
- avoid committing large font binary
- fetch font dynamically in resume generation script
- gitignore fonts folder

## Testing
- `npm test`
- `npm run generate:resume` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_684a3e2088e0832ab6fe2f63e8ece27d