### PR TITLE
Improve test imports and eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,3 +326,8 @@ myportfolio/
 - 홈 화면 ‘프로젝트 보기’ 버튼 동작 미구현 오류 수정  
   (목적에 따라 앵커 이동/페이지 이동 기능 구현 및 테스트 완료)
 - 2025-06-17 (Codex) - README에 기술 블로그 링크 추가
+- 2025-06-18 (Codex) - 테스트 코드 require 사용 개선 및 ESLint 설정 갱신
+  - BlogSection.test.tsx의 require 스타일 import를 ES6 import로 변경
+  - StatsSection.test.tsx의 불필요한 eslint-disable 지시어 수정
+  - __tests__ 폴더에 한해 no-require-imports 규칙 비활성화
+  - 테스트용 next/image, ResumeDownloadLink 모킹 타입 정의로 any 제거

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,12 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    files: ["**/__tests__/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/components/__tests__/BlogSection.test.tsx
+++ b/src/components/__tests__/BlogSection.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { BlogSection } from '../BlogSection'
+import useSWR from 'swr'
 
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => {
@@ -14,30 +15,30 @@ jest.mock('next-intl', () => ({
 
 jest.mock('swr', () => jest.fn())
 
-const useSWR = require('swr') as jest.Mock
+const mockedUseSWR = useSWR as jest.Mock
 
 describe('BlogSection', () => {
   it('renders posts when data loaded', () => {
-    useSWR.mockReturnValue({ data: { items: [{ title: 'post', link: '/p' }] }, error: undefined })
+    mockedUseSWR.mockReturnValue({ data: { items: [{ title: 'post', link: '/p' }] }, error: undefined })
     render(<BlogSection />)
     expect(screen.getByRole('heading', { name: '최신 글' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'post' })).toHaveAttribute('href', '/p')
   })
 
   it('shows empty message when no posts', () => {
-    useSWR.mockReturnValue({ data: { items: [] }, error: undefined })
+    mockedUseSWR.mockReturnValue({ data: { items: [] }, error: undefined })
     render(<BlogSection />)
     expect(screen.getByText('게시글이 없습니다.')).toBeInTheDocument()
   })
 
   it('shows error message', () => {
-    useSWR.mockReturnValue({ data: undefined, error: new Error('fail') })
+    mockedUseSWR.mockReturnValue({ data: undefined, error: new Error('fail') })
     render(<BlogSection />)
     expect(screen.getByText('블로그 글을 불러오지 못했습니다.')).toBeInTheDocument()
   })
 
   it('shows empty during loading', () => {
-    useSWR.mockReturnValue({ data: undefined, error: undefined })
+    mockedUseSWR.mockReturnValue({ data: undefined, error: undefined })
     render(<BlogSection />)
     expect(screen.getByText('게시글이 없습니다.')).toBeInTheDocument()
   })

--- a/src/components/__tests__/HeroSection.test.tsx
+++ b/src/components/__tests__/HeroSection.test.tsx
@@ -1,10 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from '@testing-library/react'
 import { HeroSection } from '../HeroSection'
+import type { AnchorHTMLAttributes } from 'react'
+
+type MockProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
 jest.mock('../ResumeDownloadLink', () => ({
   __esModule: true,
-  default: (props: any) => <a {...props} href="/resume.pdf" />,
+  default: (props: MockProps) => <a {...props} href="/resume.pdf" />,
 }))
 
 jest.mock('next-intl', () => ({

--- a/src/components/__tests__/ProjectCard.test.tsx
+++ b/src/components/__tests__/ProjectCard.test.tsx
@@ -1,11 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from '@testing-library/react'
 import { ProjectCard } from '../ProjectCard'
+import type { ComponentProps } from 'react'
+
+type MockProps = ComponentProps<'img'>
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  default: (props: any) => <img alt="" {...props} />,
+  default: (props: MockProps) => <img alt="" {...props} />,
 }))
 
 const project = {

--- a/src/components/__tests__/ProjectsSection.test.tsx
+++ b/src/components/__tests__/ProjectsSection.test.tsx
@@ -1,15 +1,16 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from '@testing-library/react'
 import { ProjectsSection } from '../ProjectsSection'
+import type { ComponentProps } from 'react'
 
 jest.mock('next-intl/server', () => ({
   getTranslations: async () => (key: string) => ({ heading: '프로젝트 모음' }[key]),
 }))
 
+type MockProps = ComponentProps<'img'>
+
 jest.mock('next/image', () => ({
   __esModule: true,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  default: (props: any) => <img alt="" {...props} />,
+  default: (props: MockProps) => <img alt="" {...props} />,
 }))
 
 jest.mock('next-intl/server', () => ({

--- a/src/components/__tests__/StatsSection.test.tsx
+++ b/src/components/__tests__/StatsSection.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from '@testing-library/react'
 
 jest.mock('next-intl/server', () => ({


### PR DESCRIPTION
## Summary
- switch BlogSection test to use ES module import
- remove unused rule disable from StatsSection test
- type mock props instead of using `any`
- disable `no-require-imports` rule for tests
- document changes in README changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a4d4dad04832a8fac90cdf535d7ec