### PR TITLE
Fix missing client directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,3 +338,6 @@ myportfolio/
   - EmailJS 관련 환경 변수 문서화 및 예시 값 추가
   - CI에서 EmailJS 환경 변수를 secrets로 주입하도록 수정
   - 환경 변수 누락 시 오류 토스트 표시 로직 추가 및 테스트 반영
+- 2025-06-20 (Codex) - Header와 HeroSection 컴포넌트 클라이언트 모드 명시
+  - `useRouter` 등 클라이언트 훅 사용에 맞게 "use client" 지시문 추가
+  - 빌드 오류를 유발하던 App Router 환경의 컴포넌트 초기화 문제 해결

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import ThemeToggle from "./ThemeToggle";
 import { useTranslations, useLocale } from "next-intl";

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import ResumeDownloadLink from "./ResumeDownloadLink";
 import { useTranslations, useLocale } from "next-intl";


### PR DESCRIPTION
## Summary
- ensure Header component is marked as a client component
- mark HeroSection as client component
- document fix in changelog

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Unknown file extension '.ts' for generateResume.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684a5312b10c832a9d6cd365aac9b67c