### PR TITLE
Improve ContactForm error handling and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,3 +341,6 @@ myportfolio/
 - 2025-06-20 (Codex) - Header와 HeroSection 컴포넌트 클라이언트 모드 명시
   - `useRouter` 등 클라이언트 훅 사용에 맞게 "use client" 지시문 추가
   - 빌드 오류를 유발하던 App Router 환경의 컴포넌트 초기화 문제 해결
+- 2025-06-22 (Codex) - ContactForm 이메일 서비스 오류 처리 강화
+  - emailjs.send 실패 시 구체적인 로그와 사용자 친화 메시지 표시
+  - 네트워크 오류 등 다양한 실패 케이스를 테스트에 추가

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -56,9 +56,9 @@ export function ContactForm() {
       setForm({ name: "", email: "", message: "" });
       show("메시지가 전송되었습니다!", "success");
     } catch (err) {
-      console.error(err);
+      console.error("Email service error:", err);
       setStatus("ERROR");
-      show("전송 중 오류가 발생했습니다.", "error");
+      show("전송 중 오류가 발생했습니다. 서비스 상태를 확인해주세요.", "error");
     } finally {
       done();
     }

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -78,7 +78,36 @@ describe('ContactForm', () => {
     fireEvent.click(screen.getByRole('button', { name: '보내기' }));
 
     await waitFor(() => expect(emailjs.send).toHaveBeenCalled());
-    expect(showMock).toHaveBeenCalledWith('전송 중 오류가 발생했습니다.', 'error');
+    expect(showMock).toHaveBeenCalledWith(
+      '전송 중 오류가 발생했습니다. 서비스 상태를 확인해주세요.',
+      'error'
+    );
+    expect(startMock).toHaveBeenCalled();
+    expect(doneMock).toHaveBeenCalled();
+  });
+
+  it('handles emailjs network failure gracefully', async () => {
+    (emailjs.send as jest.Mock).mockRejectedValue(new Error('Network Error'));
+
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: 'John Doe' },
+    });
+    fireEvent.change(screen.getByLabelText('이메일'), {
+      target: { value: 'john@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('메시지'), {
+      target: { value: 'Hello' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '보내기' }));
+
+    await waitFor(() => expect(emailjs.send).toHaveBeenCalled());
+    expect(showMock).toHaveBeenCalledWith(
+      '전송 중 오류가 발생했습니다. 서비스 상태를 확인해주세요.',
+      'error'
+    );
     expect(startMock).toHaveBeenCalled();
     expect(doneMock).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- log EmailJS failures with context
- show friendly error guidance on failure
- test network failure scenario for ContactForm
- document the update in the changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a54faadc4832a8bf849bbbdd23c81