### PR TITLE
Improve emailjs error logging and mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,3 +348,6 @@ myportfolio/
   - ContactForm에서 서비스 ID, 템플릿 ID, 공개 키 값을 함께 출력해 디버깅 편의성 향상
 - 2025-06-24 (Codex) - ContactForm 테스트 보강
   - EmailJS 환경 변수 미설정 시 오류 토스트 표시 여부를 검증하는 테스트 추가
+- 2025-06-25 (Codex) - EmailJS 테스트 및 오류 로그 개선
+  - emailjs.send Mock 기본 성공 응답을 명시하도록 수정
+  - 네트워크 오류 발생 시 err.message를 포함한 구체적 로그 출력

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -60,7 +60,7 @@ export function ContactForm() {
       setForm({ name: "", email: "", message: "" });
       show("메시지가 전송되었습니다!", "success");
     } catch (err) {
-      console.error("Email service error:", err);
+      console.error("Email service error:", (err as Error).message || err);
       setStatus("ERROR");
       show("전송 중 오류가 발생했습니다. 서비스 상태를 확인해주세요.", "error");
     } finally {

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -15,7 +15,12 @@ jest.mock('../LoadingProvider', () => ({
 }));
 
 jest.mock('emailjs-com', () => ({
-  send: jest.fn(),
+  send: jest.fn(() =>
+    Promise.resolve({
+      status: 200,
+      text: 'OK',
+    })
+  ),
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- handle `err.message` when email sending fails
- mock emailjs `send` with a default success response in tests
- document improvements in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a5a0cd690832a9d46b8513b9dd4a1