### PR TITLE
Improve EmailJS error logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# EmailJS configuration - use the exact values from your EmailJS dashboard
 NEXT_PUBLIC_EMAILJS_SERVICE_ID=<your-service-id>
 NEXT_PUBLIC_EMAILJS_TEMPLATE_ID=<your-template-id>
 NEXT_PUBLIC_EMAILJS_PUBLIC_KEY=<your-public-key>

--- a/README.md
+++ b/README.md
@@ -358,3 +358,7 @@ myportfolio/
   - EmailJS 오류 로그 메시지를 "Email service error details"로 변경
   - .env.example의 EmailJS 값 가이드 형식 통일
   - CI 워크플로우에서 환경 변수 매핑 상태 재확인
+- 2025-06-28 (Codex) - EmailJS 디버그 스크립트 및 오류 메시지 개선
+  - 네트워크 오류 로그에 err.message 우선 출력하도록 수정
+  - .env.example에 EmailJS 설정 주석 추가
+  - EmailJS 테스트용 scripts/testEmailService.ts 스크립트 추가

--- a/scripts/testEmailService.ts
+++ b/scripts/testEmailService.ts
@@ -1,0 +1,26 @@
+import emailjs from 'emailjs-com'
+
+const serviceId = process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID as string
+const templateId = process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID as string
+const publicKey = process.env.NEXT_PUBLIC_EMAILJS_PUBLIC_KEY as string
+
+emailjs
+  .send(
+    serviceId,
+    templateId,
+    {
+      from_name: 'Test User',
+      reply_to: 'test@example.com',
+      message: 'This is a test message',
+    },
+    publicKey,
+  )
+  .then(
+    (result) => {
+      console.log('Success:', result.text)
+    },
+    (error) => {
+      console.error('Error:', error.text || error)
+    },
+  )
+

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -62,7 +62,10 @@ export function ContactForm() {
       setForm({ name: "", email: "", message: "" });
       show("메시지가 전송되었습니다!", "success");
     } catch (err) {
-      console.error("Email service error details:", err);
+      console.error(
+        "Email service error details:",
+        (err as Error).message || err,
+      );
       setStatus("ERROR");
       show("전송 중 오류가 발생했습니다. 서비스 상태를 확인해주세요.", "error");
     } finally {


### PR DESCRIPTION
## Summary
- add comment to `.env.example`
- enhance EmailJS error logging
- add script for standalone EmailJS tests
- document changes in the changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a6a291520832a99dc8e96f096d162