### PR TITLE
Add loading state to BlogSection

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -12,11 +12,18 @@ type Post = {
 
 export function BlogSection() {
   const t = useTranslations('blog')
-  const { data, error } = useSWR<{ items: Post[] }>('/api/blog', fetcher)
+  const { data, error, isLoading } = useSWR<{ items: Post[] }>('/api/blog', fetcher)
 
   if (error) {
     return <p className="mt-4 text-red-500">{t('error')}</p>
   }
+
+  if (isLoading) {
+    return (
+      <p className="mt-4 text-gray-500 dark:text-gray-400 animate-pulse">Loading...</p>
+    )
+  }
+
   const posts = data?.items ?? []
   return (
     <section className="w-full mt-12" aria-labelledby="blog-heading">

--- a/src/components/__tests__/BlogSection.test.tsx
+++ b/src/components/__tests__/BlogSection.test.tsx
@@ -19,27 +19,27 @@ const mockedUseSWR = useSWR as jest.Mock
 
 describe('BlogSection', () => {
   it('renders posts when data loaded', () => {
-    mockedUseSWR.mockReturnValue({ data: { items: [{ title: 'post', link: '/p' }] }, error: undefined })
+    mockedUseSWR.mockReturnValue({ data: { items: [{ title: 'post', link: '/p' }] }, error: undefined, isLoading: false })
     render(<BlogSection />)
     expect(screen.getByRole('heading', { name: '최신 글' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'post' })).toHaveAttribute('href', '/p')
   })
 
   it('shows empty message when no posts', () => {
-    mockedUseSWR.mockReturnValue({ data: { items: [] }, error: undefined })
+    mockedUseSWR.mockReturnValue({ data: { items: [] }, error: undefined, isLoading: false })
     render(<BlogSection />)
     expect(screen.getByText('게시글이 없습니다.')).toBeInTheDocument()
   })
 
   it('shows error message', () => {
-    mockedUseSWR.mockReturnValue({ data: undefined, error: new Error('fail') })
+    mockedUseSWR.mockReturnValue({ data: undefined, error: new Error('fail'), isLoading: false })
     render(<BlogSection />)
     expect(screen.getByText('블로그 글을 불러오지 못했습니다.')).toBeInTheDocument()
   })
 
-  it('shows empty during loading', () => {
-    mockedUseSWR.mockReturnValue({ data: undefined, error: undefined })
+  it('shows loading placeholder', () => {
+    mockedUseSWR.mockReturnValue({ data: undefined, error: undefined, isLoading: true })
     render(<BlogSection />)
-    expect(screen.getByText('게시글이 없습니다.')).toBeInTheDocument()
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- show placeholder while blog posts load
- adjust BlogSection tests for loading state

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684af3c61ce8832a85b4ed086b862ae4