### PR TITLE
Remove duplicate jest mocks

### DIFF
--- a/src/components/__tests__/ProjectsSection.test.tsx
+++ b/src/components/__tests__/ProjectsSection.test.tsx
@@ -17,9 +17,6 @@ jest.mock('next/image', () => ({
   },
 }))
 
-jest.mock('next-intl/server', () => ({
-  getTranslations: async () => (key: string) => ({ heading: '프로젝트 모음' }[key]),
-}))
 
 jest.mock('@/lib/projects', () => ({
   __esModule: true,

--- a/src/components/__tests__/StatsSection.test.tsx
+++ b/src/components/__tests__/StatsSection.test.tsx
@@ -32,24 +32,6 @@ jest.mock('@/lib/projects', () => ({
   ]),
 }))
 
-jest.mock('@/lib/projects', () => ({
-  __esModule: true,
-  getProjects: jest.fn().mockResolvedValue([
-    {
-      id: 'p1',
-      title: 'proj',
-      description: 'desc',
-      image: '/img.png',
-      stack: ['React'],
-      slug: 'proj',
-      year: 2024,
-      contribution: 100,
-      features: [],
-      learnings: [],
-    },
-  ]),
-}))
-
 beforeEach(() => {
   jest.resetModules()
   jest.resetAllMocks()


### PR DESCRIPTION
## Summary
- dedupe duplicated `jest.mock` calls in StatsSection and ProjectsSection tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684af97f32d0832aa342b76d294f5b1c