### PR TITLE
Fix typing for projects search params

### DIFF
--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -21,9 +21,9 @@ export const metadata: Metadata = {
 export default async function ProjectsPage({
   searchParams,
 }: {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
+  searchParams: Record<string, string | string[] | undefined>;
 }) {
-  const params = await searchParams;
+  const params = searchParams;
   const projects = await getProjects();
   const stackParam = Array.isArray(params.stack) ? params.stack[0] : params.stack;
   const yearParam = Array.isArray(params.year) ? params.year[0] : params.year;


### PR DESCRIPTION
## Summary
- type `searchParams` as a simple record instead of a promise
- drop unnecessary `await` in projects page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684afad12c30832a967168d927e9ed79