### PR TITLE
Improve EmailJS env fallback and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
       - run: npm ci
       - run: echo "Checking environment variables"
       - run: echo $EMAILJS_SERVICE_ID && echo $EMAILJS_TEMPLATE_ID && echo $EMAILJS_USER_ID
+      - name: Validate Environment Variables
+        run: |
+          if [ -z "$EMAILJS_SERVICE_ID" ] || [ -z "$EMAILJS_TEMPLATE_ID" ] || [ -z "$EMAILJS_USER_ID" ]; then
+            echo "Missing one or more EmailJS environment variables.";
+            exit 1;
+          fi
       - run: npm run lint
       - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -379,3 +379,7 @@ myportfolio/
   - EMAILJS_* 환경 변수명으로 통일하고 env.ts 검증 로직 업데이트
   - sanitize-html 타입 정의 추가
   - StatsSection 테스트의 eslint-disable 주석 제거
+- 2025-07-04 (Codex) - EmailJS CI 검증 및 fallback 로직 강화
+  - CI 워크플로우에 환경 변수 출력 및 누락 시 실패 단계 추가
+  - getEmailJsEnv에서 경고 로그와 기본값 fallback 처리
+  - 관련 유닛 테스트 추가

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -31,32 +31,23 @@ export function ContactForm() {
       return;
     }
     setErrors({});
-    let serviceId: string
-    let templateId: string
-    let userId: string
-    try {
-      ;({ serviceId, templateId, userId } = getEmailJsEnv())
-    } catch (err) {
-      console.error('Missing EmailJS environment variables.', err)
+    const { serviceId, templateId, userId } = getEmailJsEnv()
+    if (
+      serviceId === 'default_service_id' ||
+      templateId === 'default_template_id' ||
+      userId === 'default_user_id'
+    ) {
+      console.error('Missing EmailJS environment variables.', {
+        serviceId,
+        templateId,
+        userId,
+      })
       show(
         'Email service is not configured properly. Please check the environment variables.',
         'error',
       )
       setStatus('ERROR')
       return
-    }
-
-    if (!serviceId || !templateId || !userId) {
-      console.error(
-        "Missing EmailJS environment variables. Ensure the following are set: EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, EMAILJS_USER_ID",
-        { serviceId, templateId, userId },
-      );
-      show(
-        "Email service is not configured properly. Please check the environment variables.",
-        "error",
-      );
-      setStatus("ERROR");
-      return;
     }
     start();
     try {

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -1,0 +1,36 @@
+import { getEmailJsEnv } from '../env';
+
+describe('getEmailJsEnv', () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.restoreAllMocks();
+  });
+
+  it('returns environment variables when all are set', () => {
+    process.env.EMAILJS_SERVICE_ID = 'svc';
+    process.env.EMAILJS_TEMPLATE_ID = 'tpl';
+    process.env.EMAILJS_USER_ID = 'uid';
+    expect(getEmailJsEnv()).toEqual({
+      serviceId: 'svc',
+      templateId: 'tpl',
+      userId: 'uid',
+    });
+  });
+
+  it('falls back to defaults and warns when variables are missing', () => {
+    delete process.env.EMAILJS_SERVICE_ID;
+    delete process.env.EMAILJS_TEMPLATE_ID;
+    delete process.env.EMAILJS_USER_ID;
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(getEmailJsEnv()).toEqual({
+      serviceId: 'default_service_id',
+      templateId: 'default_template_id',
+      userId: 'default_user_id',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'Missing EmailJS environment variables. Using default values.'
+    );
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,12 @@
 export function getEmailJsEnv() {
   const { EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, EMAILJS_USER_ID } = process.env
   if (!EMAILJS_SERVICE_ID || !EMAILJS_TEMPLATE_ID || !EMAILJS_USER_ID) {
-    throw new Error('Missing EmailJS environment variables')
+    console.warn('Missing EmailJS environment variables. Using default values.')
+    return {
+      serviceId: EMAILJS_SERVICE_ID || 'default_service_id',
+      templateId: EMAILJS_TEMPLATE_ID || 'default_template_id',
+      userId: EMAILJS_USER_ID || 'default_user_id',
+    }
   }
   return {
     serviceId: EMAILJS_SERVICE_ID,


### PR DESCRIPTION
## Summary
- validate EmailJS vars early in CI
- warn and fall back to default values when EmailJS env vars missing
- check for default env values in `ContactForm`
- test `getEmailJsEnv` fallback behavior
- document changes in the README changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684afecee258832a8ac7f9366307a841