### PR TITLE
Fix CI EmailJS secrets mapping and update contact form

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID || 'default_service_id' }}
-      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID || 'default_template_id' }}
-      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID || 'default_user_id' }}
+      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
+      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
+      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -386,3 +386,8 @@ myportfolio/
   - CI 워크플로우에 환경 변수 출력 및 누락 시 실패 단계 추가
   - getEmailJsEnv에서 경고 로그와 기본값 fallback 처리
   - 관련 유닛 테스트 추가
+- 2025-07-05 (Codex) - CI 환경 변수 매핑 및 오류 메시지 개선
+  - GitHub Actions에서 EmailJS secrets를 env에 직접 매핑
+  - ContactForm 네트워크 오류 메시지를 영어로 개선
+  - Projects 페이지 `PageProps` 타입 정의 추가
+  - 테스트 파일의 `<img>` 사용에 대해 ESLint 예외 처리

--- a/src/app/[locale]/projects/[slug]/__tests__/page.test.tsx
+++ b/src/app/[locale]/projects/[slug]/__tests__/page.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import { render, screen } from '@testing-library/react'
 import Page from '../page'
 import type { ComponentProps } from 'react'

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -4,6 +4,10 @@ import { ProjectFilterBar } from "@/components/ProjectFilterBar";
 import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
+interface PageProps {
+  searchParams: Record<string, string | string[] | undefined>;
+}
+
 export const metadata: Metadata = {
   title: "Projects",
   openGraph: {
@@ -18,11 +22,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function ProjectsPage({
-  searchParams,
-}: {
-  searchParams: Record<string, string | string[] | undefined>;
-}) {
+export default async function ProjectsPage({ searchParams }: PageProps) {
   const params = searchParams;
   const projects = await getProjects();
   const stackParam = Array.isArray(params.stack) ? params.stack[0] : params.stack;

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -70,7 +70,10 @@ export function ContactForm() {
         (err as Error).message || err,
       );
       setStatus("ERROR");
-      show("전송 중 오류가 발생했습니다. 서비스 상태를 확인해주세요.", "error");
+      show(
+        "There was an error sending the message. Please try again later.",
+        "error",
+      );
     } finally {
       done();
     }

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -84,7 +84,7 @@ describe('ContactForm', () => {
 
     await waitFor(() => expect(emailjs.send).toHaveBeenCalled());
     expect(showMock).toHaveBeenCalledWith(
-      '전송 중 오류가 발생했습니다. 서비스 상태를 확인해주세요.',
+      'There was an error sending the message. Please try again later.',
       'error'
     );
     expect(startMock).toHaveBeenCalled();
@@ -110,7 +110,7 @@ describe('ContactForm', () => {
 
     await waitFor(() => expect(emailjs.send).toHaveBeenCalled());
     expect(showMock).toHaveBeenCalledWith(
-      '전송 중 오류가 발생했습니다. 서비스 상태를 확인해주세요.',
+      'There was an error sending the message. Please try again later.',
       'error'
     );
     expect(startMock).toHaveBeenCalled();

--- a/src/components/__tests__/ProjectCard.test.tsx
+++ b/src/components/__tests__/ProjectCard.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import { render, screen } from '@testing-library/react'
 import { ProjectCard } from '../ProjectCard'
 import type { ComponentProps } from 'react'

--- a/src/components/__tests__/ProjectsSection.test.tsx
+++ b/src/components/__tests__/ProjectsSection.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import { render, screen } from '@testing-library/react'
 import { ProjectsSection } from '../ProjectsSection'
 import type { ComponentProps } from 'react'


### PR DESCRIPTION
## Summary
- map EmailJS environment variables directly to GitHub secrets in CI
- improve ContactForm error message
- define `PageProps` interface for projects page
- silence Next.js `<img>` warnings in tests
- document latest changes in the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b065cb1f8832a9c6e7c19984f7228