### PR TITLE
Implement repo count parameter for GitHub stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,3 +391,7 @@ myportfolio/
   - ContactForm 네트워크 오류 메시지를 영어로 개선
   - Projects 페이지 `PageProps` 타입 정의 추가
   - 테스트 파일의 `<img>` 사용에 대해 ESLint 예외 처리
+- 2025-07-06 (Codex) - GitHub API 유틸리티 리팩터링
+  - 가져올 저장소 수를 인자로 받을 수 있도록 getGithubStats 함수 개선
+  - StatsSection에서 새 유틸리티 사용하도록 수정
+  - 관련 단위 테스트 추가

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,52 +1,7 @@
-import { StatsCard } from "./StatsCard";
-import { getProjects } from "@/lib/projects";
-import { getTranslations } from "next-intl/server";
-import { getGithubToken } from "@/lib/env";
-
-async function getGithubStats() {
-  try {
-    const token = getGithubToken();
-    const userHeaders: Record<string, string> = {
-      Accept: "application/vnd.github+json",
-    };
-    if (token) {
-      userHeaders["Authorization"] = `token ${token}`;
-    }
-    const res = await fetch("https://api.github.com/users/ksaeil2001", {
-      headers: userHeaders,
-      next: { revalidate: 3600 },
-    });
-    if (!res.ok) throw new Error("Failed to fetch GitHub data");
-    const data = await res.json();
-
-    const repoHeaders: Record<string, string> = {};
-    if (token) {
-      repoHeaders["Authorization"] = `token ${token}`;
-    }
-    const repoRes = await fetch(
-      "https://api.github.com/users/ksaeil2001/repos?per_page=100",
-      Object.keys(repoHeaders).length ? { headers: repoHeaders, next: { revalidate: 3600 } } : { next: { revalidate: 3600 } },
-    );
-    if (!repoRes.ok) throw new Error("Failed to fetch repo list");
-    const repos: { stargazers_count?: number }[] = await repoRes.json();
-    const totalStars = repos.reduce(
-      (sum, repo) => sum + (repo.stargazers_count ?? 0),
-      0,
-    );
-
-    return {
-      followers: data.followers as number,
-      stars: totalStars,
-      error: false,
-    };
-  } catch {
-    return {
-      followers: 0,
-      stars: 0,
-      error: true,
-    };
-  }
-}
+import { StatsCard } from './StatsCard'
+import { getProjects } from '@/lib/projects'
+import { getTranslations } from 'next-intl/server'
+import { getGithubStats } from '@/lib/github'
 
 export async function StatsSection() {
   const t = await getTranslations('stats');

--- a/src/lib/__tests__/github.test.ts
+++ b/src/lib/__tests__/github.test.ts
@@ -1,0 +1,44 @@
+import { getGithubStats } from '../github'
+
+describe('getGithubStats', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('uses default repo count when not provided', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ followers: 1 }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+
+    await getGithubStats()
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/users/ksaeil2001/repos?per_page=5',
+      expect.anything(),
+    )
+  })
+
+  it('fetches specified number of repos', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ followers: 1 }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { stargazers_count: 2 },
+          { stargazers_count: 3 },
+        ],
+      })
+
+    const stats = await getGithubStats(2)
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/users/ksaeil2001/repos?per_page=2',
+      expect.anything(),
+    )
+    expect(stats).toEqual({ followers: 1, stars: 5, error: false })
+  })
+})

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,54 @@
+import { getGithubToken } from './env'
+
+export type GithubStats = {
+  followers: number
+  stars: number
+  error: boolean
+}
+
+export async function getGithubStats(repoCount = 5): Promise<GithubStats> {
+  try {
+    const token = getGithubToken()
+    const userHeaders: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+    }
+    if (token) {
+      userHeaders['Authorization'] = `token ${token}`
+    }
+    const res = await fetch('https://api.github.com/users/ksaeil2001', {
+      headers: userHeaders,
+      next: { revalidate: 3600 },
+    })
+    if (!res.ok) throw new Error('Failed to fetch GitHub data')
+    const data = await res.json()
+
+    const repoHeaders: Record<string, string> = {}
+    if (token) {
+      repoHeaders['Authorization'] = `token ${token}`
+    }
+    const repoRes = await fetch(
+      `https://api.github.com/users/ksaeil2001/repos?per_page=${repoCount}`,
+      Object.keys(repoHeaders).length
+        ? { headers: repoHeaders, next: { revalidate: 3600 } }
+        : { next: { revalidate: 3600 } },
+    )
+    if (!repoRes.ok) throw new Error('Failed to fetch repo list')
+    const repos: { stargazers_count?: number }[] = await repoRes.json()
+    const totalStars = repos.reduce(
+      (sum, repo) => sum + (repo.stargazers_count ?? 0),
+      0,
+    )
+
+    return {
+      followers: data.followers as number,
+      stars: totalStars,
+      error: false,
+    }
+  } catch {
+    return {
+      followers: 0,
+      stars: 0,
+      error: true,
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor GitHub stats logic into a new util `getGithubStats(repoCount)`
- update `StatsSection` to use the new utility
- add tests for the GitHub utility
- document the change in the README changelog

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0c9bd0bc832aaa8a3cdb6f9b1398