### PR TITLE
Fix CI build failures and replace deprecated emailjs package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci || npm ci
       - name: Validate Environment Variables
         run: |
           : "${EMAILJS_SERVICE_ID:?'Missing EMAILJS_SERVICE_ID'}"

--- a/README.md
+++ b/README.md
@@ -405,3 +405,6 @@ myportfolio/
   - scripts/generateResume.ts now catches network failures and skips PDF generation on fatal errors
   - Verified EMAILJS_* secrets are registered in GitHub Actions
   - CI check attempts: lint/test could not run (missing deps); build failed as tsx not found
+- 2025-07-10 (Codex) - Replace deprecated EmailJS package and improve CI
+  - Swapped `emailjs-com` for `@emailjs/browser`
+  - Added npm cache and retry logic in ci.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "myportfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@emailjs/browser": "^4.4.1",
         "@pdf-lib/fontkit": "^1.1.1",
         "@vercel/analytics": "^1.5.0",
         "@vercel/og": "^0.6.8",
-        "emailjs-com": "^3.2.0",
         "gray-matter": "^4.0.3",
         "next": "^15.3.3",
         "next-intl": "^4.1.0",
@@ -777,6 +777,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
+      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -5826,16 +5835,6 @@
       "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/emailjs-com": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/emailjs-com/-/emailjs-com-3.2.0.tgz",
-      "integrity": "sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA==",
-      "deprecated": "The SDK name changed to @emailjs/browser",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@pdf-lib/fontkit": "^1.1.1",
     "@vercel/analytics": "^1.5.0",
     "@vercel/og": "^0.6.8",
-    "emailjs-com": "^3.2.0",
     "gray-matter": "^4.0.3",
     "next": "^15.3.3",
     "next-intl": "^4.1.0",
@@ -26,7 +25,8 @@
     "remark-html": "^16.0.1",
     "rss-parser": "^3.13.0",
     "sanitize-html": "^2.17.0",
-    "swr": "^2.3.3"
+    "swr": "^2.3.3",
+    "@emailjs/browser": "^4.4.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/scripts/testEmailService.ts
+++ b/scripts/testEmailService.ts
@@ -1,4 +1,4 @@
-import emailjs from 'emailjs-com'
+import emailjs from '@emailjs/browser'
 
 const serviceId = process.env.EMAILJS_SERVICE_ID as string
 const templateId = process.env.EMAILJS_TEMPLATE_ID as string

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -5,7 +5,7 @@ import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
 interface PageProps {
-  searchParams: Record<string, string | string[] | undefined>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export const metadata: Metadata = {
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ProjectsPage({ searchParams }: PageProps) {
-  const params = searchParams;
+  const params = await searchParams;
   const projects = await getProjects();
   const stackParam = Array.isArray(params.stack) ? params.stack[0] : params.stack;
   const yearParam = Array.isArray(params.year) ? params.year[0] : params.year;

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, FormEvent, ChangeEvent } from "react";
-import emailjs from "emailjs-com";
+import emailjs from "@emailjs/browser";
 import { useToast } from "./Providers";
 import { useLoading } from "./LoadingProvider";
 import { getEmailJsEnv } from "@/lib/env";

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ContactForm } from '../ContactForm';
-import emailjs from 'emailjs-com';
+import emailjs from '@emailjs/browser';
 
 const startMock = jest.fn();
 const doneMock = jest.fn();
@@ -14,7 +14,7 @@ jest.mock('../LoadingProvider', () => ({
   useLoading: () => ({ start: startMock, done: doneMock }),
 }));
 
-jest.mock('emailjs-com', () => ({
+jest.mock('@emailjs/browser', () => ({
   send: jest.fn(() =>
     Promise.resolve({
       status: 200,


### PR DESCRIPTION
## Summary
- swap deprecated `emailjs-com` for `@emailjs/browser`
- add npm cache and retry logic to CI workflow
- update import paths for EmailJS
- fix Projects page types to satisfy Next.js
- update test and script imports
- document changes in changelog

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b624c33bc832a964255ffe533dca6