### PR TITLE
Add network policy docs for font downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ npm run test
 
 1. registry.npmjs.org 접근이 차단되어 있는지 확인하고, 차단 시 IT/보안팀에 허용을 요청합니다.
 2. 내부 npm 미러 또는 프록시가 있다면 `.npmrc`에 해당 주소를 지정하거나 `HTTP_PROXY` / `HTTPS_PROXY` 환경 변수를 설정합니다.
-3. CI 워크플로와 README에 EmailJS 등 환경 변수 설정 방법을 명확히 기록합니다.
-4. 접근 권한이 복구된 후 아래 명령어를 순서대로 실행하여 모든 단계가 통과하는지 확인합니다.
+3. `raw.githubusercontent.com` 도메인이 차단되어 있으면 이력서 PDF 생성 시 폰트 다운로드가 실패합니다. 허용이 어렵다면 `public/fonts` 폴더에 폰트를 미리 배치하고 스크립트 경로를 수정합니다.
+4. CI 워크플로와 README에 EmailJS 등 환경 변수 설정 방법을 명확히 기록합니다.
+5. 접근 권한이 복구된 후 아래 명령어를 순서대로 실행하여 모든 단계가 통과하는지 확인합니다.
 
    ```bash
    npm ci
@@ -99,7 +100,7 @@ npm run test
    npm run build
    ```
 
-5. 네트워크 정책, 장애 원인, 해결 과정을 Changelog 섹션에 상세히 기록합니다.
+6. 네트워크 정책, 장애 원인, 해결 과정을 Changelog 섹션에 상세히 기록합니다.
 ---
 
 ## 📌 주요 기능 및 UI 구성 요약
@@ -436,3 +437,6 @@ myportfolio/
   - Replaced "EmailJS public key" with "EmailJS 사용자 ID" in contact page section
  - 2025-07-14 (Codex) - Provide CI fallback for missing EmailJS secrets
   - ci.yml now assigns default EmailJS values if GitHub secrets are undefined
+
+- 2025-07-15 (Codex) - Document font download network policy
+  - Added docs/network-policy.md and updated network guide.

--- a/docs/network-policy.md
+++ b/docs/network-policy.md
@@ -1,0 +1,16 @@
+# Network Policy and Font Download Guide
+
+This document summarizes how to handle network restrictions that block access to `raw.githubusercontent.com`, which is required for downloading fonts used by `scripts/generateResume.ts`.
+
+## 1. Verify Network Policy
+- Check whether `raw.githubusercontent.com` is blocked on build and deployment environments.
+- If blocked, request IT or the security team to allow access to this domain for font downloads.
+
+## 2. Workaround if Whitelisting is Not Possible
+- Pre-download required font files and store them inside `public/fonts/` or an internal server.
+- Update the font path in `scripts/generateResume.ts` or provide a custom download URL that is accessible within your network.
+- Ensure fallback fonts are available so that the build does not fail even when external fetches are blocked.
+
+## 3. Document Policy Changes
+- Record any firewall policy updates and troubleshooting steps in the `README.md` Changelog.
+- Keep this document up to date when network rules change or when new download mirrors are introduced.


### PR DESCRIPTION
## Summary
- document handling for raw.githubusercontent.com font downloads in README
- add detailed network policy guide in docs

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c49c46e2c832a9584d42d98258999