### PR TITLE
Fix CI env validation and intl config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       - run: npm ci || npm ci
       - name: Validate Environment Variables
         run: |
-          : "${EMAILJS_SERVICE_ID:='default_service_id'}"
-          : "${EMAILJS_TEMPLATE_ID:='default_template_id'}"
-          : "${EMAILJS_USER_ID:='default_user_id'}"
+          : "${EMAILJS_SERVICE_ID:?'Missing EmailJS service ID'}"
+          : "${EMAILJS_TEMPLATE_ID:?'Missing EmailJS template ID'}"
+          : "${EMAILJS_USER_ID:?'Missing EmailJS user ID'}"
       - run: npm run lint
       - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -452,3 +452,7 @@ myportfolio/
   - Resume generator sanitizes text if only ASCII fonts are available
   - Locale routes statically generated via `generateStaticParams`
   - Added placeholder `next-intl.config.js` but build still fails without proper plugin
+- 2025-07-19 (Codex) - EmailJS env validation and intl config fixes
+  - CI workflow now fails if EMAILJS secrets are missing
+  - next-intl.config.js exports locales and defaultLocale
+  - ContactForm validates missing EmailJS variables without defaults

--- a/next-intl.config.js
+++ b/next-intl.config.js
@@ -1,6 +1,4 @@
-export default function getRequestConfig({ locale } = { locale: 'ko' }) {
-  return {
-    locale: locale || 'ko',
-    messages: require(`./src/dictionaries/${locale || 'ko'}.json`),
-  };
-}
+module.exports = {
+  locales: ['en', 'ko'],
+  defaultLocale: 'en'
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,8 @@
 import type { NextConfig } from "next";
 import path from "path";
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin('./next-intl.config.js');
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -33,4 +36,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -32,18 +32,10 @@ export function ContactForm() {
     }
     setErrors({});
     const { serviceId, templateId, userId } = getEmailJsEnv()
-    if (
-      serviceId === 'default_service_id' ||
-      templateId === 'default_template_id' ||
-      userId === 'default_user_id'
-    ) {
-      console.error('Missing EmailJS environment variables.', {
-        serviceId,
-        templateId,
-        userId,
-      })
+    if (!serviceId || !templateId || !userId) {
+      console.error('Missing EmailJS environment variables.')
       show(
-        'Email service is not configured properly. Please check the environment variables.',
+        'Email service is not configured properly.',
         'error',
       )
       setStatus('ERROR')

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -138,7 +138,7 @@ describe('ContactForm', () => {
 
     await waitFor(() =>
       expect(showMock).toHaveBeenCalledWith(
-        'Email service is not configured properly. Please check the environment variables.',
+        'Email service is not configured properly.',
         'error',
       ),
     );

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -19,18 +19,14 @@ describe('getEmailJsEnv', () => {
     });
   });
 
-  it('falls back to defaults and warns when variables are missing', () => {
+  it('returns undefined values when variables are missing', () => {
     delete process.env.EMAILJS_SERVICE_ID;
     delete process.env.EMAILJS_TEMPLATE_ID;
     delete process.env.EMAILJS_USER_ID;
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     expect(getEmailJsEnv()).toEqual({
-      serviceId: 'default_service_id',
-      templateId: 'default_template_id',
-      userId: 'default_user_id',
+      serviceId: undefined,
+      templateId: undefined,
+      userId: undefined,
     });
-    expect(warn).toHaveBeenCalledWith(
-      'Missing EmailJS environment variables. Using default values.'
-    );
   });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,13 +1,7 @@
 export function getEmailJsEnv() {
-  const { EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, EMAILJS_USER_ID } = process.env
-  if (!EMAILJS_SERVICE_ID || !EMAILJS_TEMPLATE_ID || !EMAILJS_USER_ID) {
-    console.warn('Missing EmailJS environment variables. Using default values.')
-    return {
-      serviceId: EMAILJS_SERVICE_ID || 'default_service_id',
-      templateId: EMAILJS_TEMPLATE_ID || 'default_template_id',
-      userId: EMAILJS_USER_ID || 'default_user_id',
-    }
-  }
+  const { EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, EMAILJS_USER_ID } =
+    process.env
+
   return {
     serviceId: EMAILJS_SERVICE_ID,
     templateId: EMAILJS_TEMPLATE_ID,


### PR DESCRIPTION
## Summary
- validate EmailJS secrets strictly in CI
- adjust contact form env handling
- update env utilities and tests
- replace intl config with static object and integrate plugin
- document changes in changelog

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Couldn't find next-intl config file)*

------
https://chatgpt.com/codex/tasks/task_e_684ce4f9a670832a8d9cc5bdc371aaaa