### PR TITLE
Add accessible login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,3 +456,6 @@ myportfolio/
   - CI workflow now fails if EMAILJS secrets are missing
   - next-intl.config.js exports locales and defaultLocale
   - ContactForm validates missing EmailJS variables without defaults
+- 2025-07-20 (Codex) - Added accessible login page
+  - Created LoginForm component with aria attributes and validation
+  - Added /login route and navigation links

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -1,0 +1,27 @@
+import { LoginForm } from "@/components/LoginForm";
+import { getTranslations } from "next-intl/server";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Login",
+  openGraph: {
+    images: [
+      {
+        url: "/api/og?title=Login",
+        width: 1200,
+        height: 630,
+        alt: "Login",
+      },
+    ],
+  },
+};
+
+export default async function LoginPage() {
+  const t = await getTranslations('login');
+  return (
+    <main id="main-content" className="mx-auto w-full max-w-md p-8 sm:p-20">
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{t('title')}</h1>
+      <LoginForm />
+    </main>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,6 +37,9 @@ export function Header() {
           <Link href={{ pathname: '/contact' }} locale={locale} className="hover:underline">
             {t('contact')}
           </Link>
+          <Link href={{ pathname: '/login' }} locale={locale} className="hover:underline">
+            {t('login')}
+          </Link>
         </nav>
         <div className="flex items-center gap-2">
           <select
@@ -77,6 +80,11 @@ export function Header() {
               <li>
                 <Link href={{ pathname: '/contact' }} locale={locale} className="block px-2 py-2 hover:underline">
                   {t('contact')}
+                </Link>
+              </li>
+              <li>
+                <Link href={{ pathname: '/login' }} locale={locale} className="block px-2 py-2 hover:underline">
+                  {t('login')}
                 </Link>
               </li>
             </ul>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, ChangeEvent, FormEvent } from "react";
+import { useTranslations } from "next-intl";
+
+export function LoginForm() {
+  const t = useTranslations('login');
+  const [form, setForm] = useState({ email: "", password: "" });
+  const [errors, setErrors] = useState<{ email?: string; password?: string }>({});
+  const [status, setStatus] = useState<"IDLE" | "SUCCESS">("IDLE");
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const newErrors: { email?: string; password?: string } = {};
+    if (!form.email.trim()) newErrors.email = t('emailRequired');
+    if (!form.password.trim()) newErrors.password = t('passwordRequired');
+    if (Object.keys(newErrors).length) {
+      setErrors(newErrors);
+      return;
+    }
+    setErrors({});
+    setStatus("SUCCESS");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-8 space-y-4" aria-labelledby="login-form-heading">
+      <h2 id="login-form-heading" className="sr-only">
+        {t('title')}
+      </h2>
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          {t('email')}
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          className={`mt-1 w-full rounded-md p-2 bg-white dark:bg-neutral-900 border ${errors.email ? "border-red-500" : "border-gray-300 dark:border-gray-700"}`}
+          aria-invalid={errors.email ? "true" : undefined}
+          value={form.email}
+          onChange={handleChange}
+        />
+        {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email}</p>}
+      </div>
+      <div>
+        <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          {t('password')}
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          required
+          className={`mt-1 w-full rounded-md p-2 bg-white dark:bg-neutral-900 border ${errors.password ? "border-red-500" : "border-gray-300 dark:border-gray-700"}`}
+          aria-invalid={errors.password ? "true" : undefined}
+          value={form.password}
+          onChange={handleChange}
+        />
+        {errors.password && <p className="mt-1 text-sm text-red-600">{errors.password}</p>}
+      </div>
+      <button
+        type="submit"
+        className="rounded-md bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700"
+      >
+        {t('submit')}
+      </button>
+      <div aria-live="polite" className="sr-only">
+        {status === "SUCCESS" && t('success')}
+      </div>
+    </form>
+  );
+}

--- a/src/components/__tests__/LoginForm.test.tsx
+++ b/src/components/__tests__/LoginForm.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LoginForm } from '../LoginForm';
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const dict: Record<string, string> = {
+      title: '로그인',
+      email: '이메일',
+      password: '비밀번호',
+      submit: '로그인',
+      emailRequired: '이메일을 입력해주세요',
+      passwordRequired: '비밀번호를 입력해주세요',
+      success: '로그인되었습니다!'
+    };
+    return dict[key];
+  },
+}));
+
+describe('LoginForm', () => {
+  it('shows validation errors when fields are empty', () => {
+    render(<LoginForm />);
+    fireEvent.submit(screen.getByRole('form', { name: '로그인' }));
+    expect(screen.getByText('이메일을 입력해주세요')).toBeInTheDocument();
+    expect(screen.getByText('비밀번호를 입력해주세요')).toBeInTheDocument();
+  });
+
+  it('shows success message on valid submit', () => {
+    render(<LoginForm />);
+    fireEvent.change(screen.getByLabelText('이메일'), {
+      target: { value: 'a@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('비밀번호'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '로그인' }));
+    expect(screen.getByText('로그인되었습니다!')).toBeInTheDocument();
+  });
+});

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -29,7 +29,8 @@
     "contact": "Contact",
     "language": "Language",
     "korean": "Korean",
-    "english": "English"
+    "english": "English",
+    "login": "Login"
   },
   "notFound": {
     "title": "Page not found",
@@ -69,6 +70,15 @@
     "github": "GitHub",
     "blog": "Blog",
     "download": "Download PDF Resume"
+  },
+  "login": {
+    "title": "Login",
+    "email": "Email",
+    "password": "Password",
+    "submit": "Log In",
+    "emailRequired": "Please enter your email",
+    "passwordRequired": "Please enter your password",
+    "success": "Login submitted"
   },
   "resumeLink": {
     "unavailable": "Resume is not ready yet",

--- a/src/dictionaries/ko.json
+++ b/src/dictionaries/ko.json
@@ -29,7 +29,8 @@
     "contact": "Contact",
     "language": "언어",
     "korean": "한국어",
-    "english": "영어"
+    "english": "영어",
+    "login": "로그인"
   },
   "notFound": {
     "title": "페이지를 찾을 수 없습니다.",
@@ -69,6 +70,15 @@
     "github": "GitHub",
     "blog": "블로그",
     "download": "PDF 이력서 다운로드"
+  },
+  "login": {
+    "title": "로그인",
+    "email": "이메일",
+    "password": "비밀번호",
+    "submit": "로그인",
+    "emailRequired": "이메일을 입력해주세요",
+    "passwordRequired": "비밀번호를 입력해주세요",
+    "success": "로그인되었습니다!"
   },
   "resumeLink": {
     "unavailable": "이력서 준비 중입니다",


### PR DESCRIPTION
## Summary
- add LoginForm component with accessibility features
- add /login page and menu link
- localize login strings in dictionaries
- cover LoginForm with unit tests
- document changes in README

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: TypeError during prerendering)*

------
https://chatgpt.com/codex/tasks/task_e_684cf4e7c6c4832a958ec2bddf4de0b7