### PR TITLE
Add EmailJS secrets inspection report

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,3 +474,5 @@ myportfolio/
   - Added /login route and navigation links
 - 2025-07-21 (Codex) - Document GitHub Secrets setup for EmailJS
   - README에 EmailJS 환경 변수 설정 절차 및 CI 검증 스크립트 추가
+- 2025-07-22 (Codex) - EmailJS secrets inspection report added
+  - Added docs/emailjs-secrets-report.md with inspection details

--- a/docs/emailjs-secrets-report.md
+++ b/docs/emailjs-secrets-report.md
@@ -1,0 +1,11 @@
+# EmailJS Secrets Inspection
+
+The CI workflow failed due to missing EmailJS environment variables. The following table summarizes the check.
+
+| 점검 항목 | 상태 | 원인/설명 | Codex 개선 예시 |
+|-----------|------|-----------|----------------|
+| EMAILJS_SERVICE_ID | 누락 | GitHub Secrets에 값이 없거나 잘못 등록됨 | EmailJS 대시보드에서 발급받아 등록 |
+| EMAILJS_TEMPLATE_ID | 누락 | GitHub Secrets에 값이 없거나 잘못 등록됨 | 동일 |
+| EMAILJS_USER_ID | 누락 | GitHub Secrets에 값이 없거나 잘못 등록됨 | 동일 |
+
+Codex 기준 위반 없음. Best Practice: secrets는 반드시 실제 운영 환경에서만 등록/사용할 것.


### PR DESCRIPTION
## Summary
- add `emailjs-secrets-report.md` documenting that EmailJS secrets are missing
- note the new document in the Changelog

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: prerender error)*

------
https://chatgpt.com/codex/tasks/task_e_684d1e532574832aa9fd30bbbef1155c