### PR TITLE
Fix EmailJS secret validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # EmailJS credentials provided via GitHub Secrets
+      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
       EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
       EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
-      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,9 +28,9 @@ jobs:
       - run: npm ci || npm ci
       - name: Validate Environment Variables
         run: |
-          : "${EMAILJS_SERVICE_ID:?'Missing EmailJS service ID'}"
-          : "${EMAILJS_TEMPLATE_ID:?'Missing EmailJS template ID'}"
-          : "${EMAILJS_USER_ID:?'Missing EmailJS user ID'}"
+          : "${EMAILJS_SERVICE_ID:?'Missing EmailJS service ID. Please set it in GitHub Secrets.'}"
+          : "${EMAILJS_TEMPLATE_ID:?'Missing EmailJS template ID. Please set it in GitHub Secrets.'}"
+          : "${EMAILJS_USER_ID:?'Missing EmailJS user ID. Please set it in GitHub Secrets.'}"
       - run: npm run lint
       - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -478,3 +478,5 @@ myportfolio/
   - Added docs/emailjs-secrets-report.md with inspection details
 - 2025-07-23 (Codex) - CI workflow EmailJS env order fixed
   - ci.yml env section reordered to match documented variable sequence
+ - 2025-07-24 (Codex) - CI 환경 변수 검증 메시지 개선
+   - EmailJS secrets 누락 시 구체적 안내 메시지를 출력하도록 ci.yml 수정


### PR DESCRIPTION
## Summary
- enforce EmailJS secret order in ci.yml
- improve CI validation messages for missing EmailJS secrets
- document change in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d26b7142c832ab498ed07588b716c