### PR TITLE
Fix CI env validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,18 @@ jobs:
       - run: npm ci || npm ci
       - name: Validate Environment Variables
         run: |
-          : "${EMAILJS_SERVICE_ID:?'Missing EmailJS service ID. Please set it in GitHub Secrets.'}"
-          : "${EMAILJS_TEMPLATE_ID:?'Missing EmailJS template ID. Please set it in GitHub Secrets.'}"
-          : "${EMAILJS_USER_ID:?'Missing EmailJS user ID. Please set it in GitHub Secrets.'}"
+          if [ -z "${EMAILJS_SERVICE_ID}" ]; then
+            echo "::error::EMAILJS_SERVICE_ID is missing. Set it as a GitHub Secret."
+            exit 1
+          fi
+          if [ -z "${EMAILJS_TEMPLATE_ID}" ]; then
+            echo "::error::EMAILJS_TEMPLATE_ID is missing. Set it as a GitHub Secret."
+            exit 1
+          fi
+          if [ -z "${EMAILJS_USER_ID}" ]; then
+            echo "::error::EMAILJS_USER_ID is missing. Set it as a GitHub Secret."
+            exit 1
+          fi
       - run: npm run lint
       - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -478,5 +478,7 @@ myportfolio/
   - Added docs/emailjs-secrets-report.md with inspection details
 - 2025-07-23 (Codex) - CI workflow EmailJS env order fixed
   - ci.yml env section reordered to match documented variable sequence
- - 2025-07-24 (Codex) - CI 환경 변수 검증 메시지 개선
+- 2025-07-24 (Codex) - CI 환경 변수 검증 메시지 개선
    - EmailJS secrets 누락 시 구체적 안내 메시지를 출력하도록 ci.yml 수정
+- 2025-07-25 (Codex) - CI 환경 변수 검증 스크립트 업데이트
+  - GitHub Actions에서 EmailJS 서비스/템플릿/사용자 ID가 비어 있으면 오류 메시지와 함께 즉시 실패하도록 스크립트 수정


### PR DESCRIPTION
## Summary
- ensure GitHub Actions fails when EMAILJS secrets are missing
- document EmailJS CI update in changelog

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Next.js build worker exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_684d29d82864832a8aa3e1fbcdf9f6ca