### PR TITLE
Improve CI error message for EmailJS secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      # EmailJS credentials provided via GitHub Secrets
-      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
-      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
-      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
+      # EmailJS credentials should be configured as GitHub Secrets.
+      # CI will fail if these values remain as the fallback 'placeholder'.
+      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID || 'placeholder' }}
+      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID || 'placeholder' }}
+      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID || 'placeholder' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,16 +29,21 @@ jobs:
       - run: npm ci || npm ci
       - name: Validate Environment Variables
         run: |
-          if [ -z "${EMAILJS_SERVICE_ID}" ]; then
-            echo "::error::EMAILJS_SERVICE_ID is missing. Set it as a GitHub Secret."
-            exit 1
+          missing=false
+          if [ "${EMAILJS_SERVICE_ID}" = "placeholder" ]; then
+            echo "::warning::EMAILJS_SERVICE_ID secret is not configured."
+            missing=true
           fi
-          if [ -z "${EMAILJS_TEMPLATE_ID}" ]; then
-            echo "::error::EMAILJS_TEMPLATE_ID is missing. Set it as a GitHub Secret."
-            exit 1
+          if [ "${EMAILJS_TEMPLATE_ID}" = "placeholder" ]; then
+            echo "::warning::EMAILJS_TEMPLATE_ID secret is not configured."
+            missing=true
           fi
-          if [ -z "${EMAILJS_USER_ID}" ]; then
-            echo "::error::EMAILJS_USER_ID is missing. Set it as a GitHub Secret."
+          if [ "${EMAILJS_USER_ID}" = "placeholder" ]; then
+            echo "::warning::EMAILJS_USER_ID secret is not configured."
+            missing=true
+          fi
+          if [ "$missing" = true ]; then
+            echo "::error::EmailJS secrets are required. Add EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, and EMAILJS_USER_ID in repository secrets."
             exit 1
           fi
       - run: npm run lint

--- a/README.md
+++ b/README.md
@@ -62,12 +62,19 @@
 > 저장소 **Settings > Secrets and variables > Actions** 메뉴에서 각각
 > `EMAILJS_SERVICE_ID`, `EMAILJS_TEMPLATE_ID`, `EMAILJS_USER_ID` 이름으로
 > 새 Secret을 등록해야 합니다.
-> 워크플로우에서는 다음 스크립트로 값 존재 여부를 검증합니다.
+> 워크플로우에서는 다음과 같이 기본값을 사용해도 경고 후 실패하도록 설정됩니다.
+>
+> ```yaml
+> EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID || 'placeholder' }}
+> EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID || 'placeholder' }}
+> EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID || 'placeholder' }}
+> ```
 >
 > ```bash
-> : "${EMAILJS_SERVICE_ID:?'Missing EmailJS service ID'}"
-> : "${EMAILJS_TEMPLATE_ID:?'Missing EmailJS template ID'}"
-> : "${EMAILJS_USER_ID:?'Missing EmailJS user ID'}"
+> if [ "${EMAILJS_SERVICE_ID}" = "placeholder" ]; then
+>   echo "::error::EmailJS secrets are required."
+>   exit 1
+> fi
 > ```
 > Secrets 등록 후 CI를 재실행하면 오류 없이 진행됩니다.
 
@@ -499,3 +506,6 @@ myportfolio/
 - 2025-07-30 (Codex) - Repository guidelines file and pretest lint script
   - AGENTS.md 파일을 추가해 작업 규칙 명세
   - `package.json`의 `pretest` 스크립트로 커밋 전 ESLint 자동 실행
+- 2025-07-31 (Codex) - CI 워크플로우 EmailJS 비밀값 기본값 및 경고 추가
+  - ci.yml에서 EmailJS secrets 미설정 시 'placeholder'로 대체 후 경고 출력
+  - README에 필수 secrets 설정 필요성을 강조


### PR DESCRIPTION
## Summary
- warn when EmailJS secrets aren't configured
- clarify EmailJS secrets setup with placeholder values in docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d60416ad8832ab994490be99e64a1