### PR TITLE
Attempt fix for next-intl build

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,3 +517,4 @@ myportfolio/
 - 2025-08-01 (Codex) - Offline resume generation option
   - `OFFLINE_MODE` 환경 변수를 추가해 네트워크 연결 없이 이력서 PDF 생성 가능
 main
+- 2025-08-02 (Codex) - Attempted build fix for next-intl

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import createMiddleware from 'next-intl/middleware'
+import { locales, defaultLocale } from './next-intl.config.js'
+
+export default createMiddleware({
+  locales,
+  defaultLocale,
+})
+
+export const config = {
+  matcher: ['/((?!_next|.*\\..*).*)'],
+}

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -3,6 +3,10 @@ import { getTranslations } from "next-intl/server";
 import type { TimelineEntry } from "@/data/types";
 import timelineData from "../../../../content/about/timeline.json";
 
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
 export const metadata = {
   title: "About",
   openGraph: {
@@ -19,8 +23,9 @@ export const metadata = {
 
 const timeline: TimelineEntry[] = timelineData;
 
-export default async function AboutPage() {
-  const t = await getTranslations('about');
+export default async function AboutPage({ params }: PageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'about' });
   return (
     <main id="main-content" className="mx-auto w-full max-w-5xl space-y-16 p-8 sm:p-20">
       <section aria-labelledby="about-heading">

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -2,6 +2,10 @@ import { ContactForm } from "@/components/ContactForm";
 import ResumeDownloadLink from "@/components/ResumeDownloadLink";
 import { getTranslations } from "next-intl/server";
 
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
 export const metadata = {
   title: "Contact",
   openGraph: {
@@ -16,8 +20,9 @@ export const metadata = {
   },
 };
 
-export default async function ContactPage() {
-  const t = await getTranslations('contact');
+export default async function ContactPage({ params }: PageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'contact' });
   return (
     <main id="main-content" className="mx-auto w-full max-w-5xl p-8 sm:p-20">
       <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{t('title')}</h1>

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -2,6 +2,10 @@ import { LoginForm } from "@/components/LoginForm";
 import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
 export const metadata: Metadata = {
   title: "Login",
   openGraph: {
@@ -16,8 +20,9 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function LoginPage() {
-  const t = await getTranslations('login');
+export default async function LoginPage({ params }: PageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'login' });
   return (
     <main id="main-content" className="mx-auto w-full max-w-md p-8 sm:p-20">
       <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{t('title')}</h1>

--- a/src/app/[locale]/projects/[slug]/__tests__/page.test.tsx
+++ b/src/app/[locale]/projects/[slug]/__tests__/page.test.tsx
@@ -55,7 +55,7 @@ const { notFound } = require('next/navigation')
 
 describe('Project detail page', () => {
   it('renders project content', async () => {
-    const Comp = await Page({ params: Promise.resolve({ slug: 'proj-one' }) })
+    const Comp = await Page({ params: { slug: 'proj-one', locale: 'en' } })
     render(Comp)
     expect(screen.getByRole('heading', { name: 'Project One' })).toBeInTheDocument()
     expect(screen.getByText('Desc')).toBeInTheDocument()
@@ -65,7 +65,7 @@ describe('Project detail page', () => {
 
   it('calls notFound when slug missing', async () => {
     await expect(
-      Page({ params: Promise.resolve({ slug: 'missing' }) })
+      Page({ params: { slug: 'missing', locale: 'en' } })
     ).rejects.toThrow('not-found')
     expect(notFound).toHaveBeenCalled()
   })

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -5,7 +5,11 @@ import { getTranslations } from "next-intl/server";
 import type { JSX } from "react";
 import type { Metadata } from "next";
 
-export async function generateMetadata({ params }: { params: Promise<{ slug: string | string[] | undefined }> }): Promise<Metadata> {
+interface PageProps {
+  params: Promise<{ slug: string | string[] | undefined; locale: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const slugValue = Array.isArray(slug) ? slug[0] : slug;
   const projects = await getProjects();
@@ -25,12 +29,8 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     },
   };
 }
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ slug: string | string[] | undefined }>;
-}): Promise<JSX.Element> {
-  const { slug } = await params;
+export default async function Page({ params }: PageProps): Promise<JSX.Element> {
+  const { slug, locale } = await params;
   const slugValue = Array.isArray(slug) ? slug[0] : slug;
   const projects = await getProjects();
   const project = projects.find((p) => p.slug === slugValue);
@@ -39,7 +39,7 @@ export default async function Page({
     notFound();
   }
 
-  const t = await getTranslations('projects');
+  const t = await getTranslations({ locale, namespace: 'projects' });
   return (
     <main id="main-content" className="mx-auto w-full max-w-5xl p-8">
       <h1 className="text-3xl font-bold text-gray-900 dark:text-white">

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,8 +1,8 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+
 export async function getDictionary(locale: string) {
-  switch (locale) {
-    case 'en':
-      return (await import('../dictionaries/en.json')).default
-    default:
-      return (await import('../dictionaries/ko.json')).default
-  }
+  const filePath = path.join(process.cwd(), 'src', 'dictionaries', `${locale}.json`)
+  const data = await readFile(filePath, 'utf8')
+  return JSON.parse(data)
 }


### PR DESCRIPTION
## Summary
- adjust next-intl usage and add middleware
- update tests and dictionary loader

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: `TypeError: e is not a function`)*

------
https://chatgpt.com/codex/tasks/task_e_684d8d315eb0832ab714f24edacc3dc9