### PR TITLE
Enhance EmailJS secret check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Check EmailJS Secrets
         run: |
           missing=()
-          [[ -z "$EMAILJS_SERVICE_ID" ]] && missing+=("EMAILJS_SERVICE_ID")
-          [[ -z "$EMAILJS_TEMPLATE_ID" ]] && missing+=("EMAILJS_TEMPLATE_ID")
-          [[ -z "$EMAILJS_USER_ID" ]] && missing+=("EMAILJS_USER_ID")
+          [[ -z "$EMAILJS_SERVICE_ID" ]] && missing+=("EMAILJS_SERVICE_ID: Not Set")
+          [[ -z "$EMAILJS_TEMPLATE_ID" ]] && missing+=("EMAILJS_TEMPLATE_ID: Not Set")
+          [[ -z "$EMAILJS_USER_ID" ]] && missing+=("EMAILJS_USER_ID: Not Set")
           if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing secrets: ${missing[*]}. Add them in repository settings."
+            echo "::error::Missing secrets: ${missing[*]}"
             exit 1
           fi
           echo "EmailJS secrets are correctly configured."

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ GitHub Actions CI 환경에서 위 EmailJS 변수들이 누락되면 워크플�
 > ```
 > 또한 워크플로우 시작 단계에서 secrets 존재 여부를 확인하는 `check-secrets` job이 추가되었습니다.
 > Secrets 등록 후 CI를 재실행하면 오류 없이 진행됩니다.
+> 누락된 항목은 `EMAILJS_SERVICE_ID: Not Set` 형식으로 표시되어 어떤 값이 비어 있는지 즉시 파악할 수 있습니다.
 
 <p>
   <img src="https://img.shields.io/badge/Vercel-000000?style=for-the-badge&logo=vercel&logoColor=white" />
@@ -522,3 +523,5 @@ myportfolio/
   - ci.yml의 누락 경고에 README 링크를 추가해 EmailJS 시크릿 설정 방법을 안내
 - 2025-08-04 (Codex) - CI workflow secret check job 추가
 - 2025-08-05 (Codex) - CI secret check clarifies which EmailJS values are missing
+- 2025-08-06 (Codex) - Secrets check provides placeholder details
+  - check-secrets job now prints `EMAILJS_SERVICE_ID: Not Set` style messages for each missing value


### PR DESCRIPTION
## Summary
- improve EmailJS secrets check step to display `Not Set` placeholders
- document improved error output in README
- log entry for the change in Changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684da61d7b1c832a9aa02ef73c4066d4