### PR TITLE
Fix EmailJS secret check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,16 @@ jobs:
   check-secrets:
     runs-on: ubuntu-latest
     env:
-      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
-      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
-      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
+      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID || 'default_service_id' }}
+      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID || 'default_template_id' }}
+      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID || 'default_user_id' }}
     steps:
       - name: Check EmailJS Secrets
         run: |
           missing=()
-          [[ -z "$EMAILJS_SERVICE_ID" ]] && missing+=("EMAILJS_SERVICE_ID: Not Set")
-          [[ -z "$EMAILJS_TEMPLATE_ID" ]] && missing+=("EMAILJS_TEMPLATE_ID: Not Set")
-          [[ -z "$EMAILJS_USER_ID" ]] && missing+=("EMAILJS_USER_ID: Not Set")
+          [[ -z "$EMAILJS_SERVICE_ID" || "$EMAILJS_SERVICE_ID" == 'default_service_id' ]] && missing+=("EMAILJS_SERVICE_ID: Not Set")
+          [[ -z "$EMAILJS_TEMPLATE_ID" || "$EMAILJS_TEMPLATE_ID" == 'default_template_id' ]] && missing+=("EMAILJS_TEMPLATE_ID: Not Set")
+          [[ -z "$EMAILJS_USER_ID" || "$EMAILJS_USER_ID" == 'default_user_id' ]] && missing+=("EMAILJS_USER_ID: Not Set")
           if [ ${#missing[@]} -ne 0 ]; then
             echo "::error::Missing secrets: ${missing[*]}"
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 # resume
 public/resume.pdf
 public/fonts/
+.npm_cache/

--- a/README.md
+++ b/README.md
@@ -525,3 +525,7 @@ myportfolio/
 - 2025-08-05 (Codex) - CI secret check clarifies which EmailJS values are missing
 - 2025-08-06 (Codex) - Secrets check provides placeholder details
   - check-secrets job now prints `EMAILJS_SERVICE_ID: Not Set` style messages for each missing value
+- 2025-08-07 (Codex) - CI workflow fallback values for EmailJS secrets
+  - ci.yml assigns default values when secrets are missing and validates them accordingly
+  - Added .npm_cache to .gitignore to prevent large cache files from being committed
+


### PR DESCRIPTION
## Summary
- allow default env values for EmailJS secrets in CI
- flag defaults as missing during secret check
- ignore local `.npm_cache`
- document the change in the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e3855777c832a806d44a708f6a7aa