### PR TITLE
Add runtime validation for EmailJS secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,4 +528,7 @@ myportfolio/
 - 2025-08-07 (Codex) - CI workflow fallback values for EmailJS secrets
   - ci.yml assigns default values when secrets are missing and validates them accordingly
   - Added .npm_cache to .gitignore to prevent large cache files from being committed
+- 2025-08-08 (Codex) - Runtime validation for EmailJS secrets
+  - Added `validateEmailJsEnv()` in `src/lib/env.ts` and integrated with `ContactForm`
+  - Updated tests to cover the new validation logic
 

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -4,7 +4,7 @@ import { useState, FormEvent, ChangeEvent } from "react";
 import emailjs from "@emailjs/browser";
 import { useToast } from "./Providers";
 import { useLoading } from "./LoadingProvider";
-import { getEmailJsEnv } from "@/lib/env";
+import { getEmailJsEnv, validateEmailJsEnv } from "@/lib/env";
 
 export function ContactForm() {
   const [form, setForm] = useState({ name: "", email: "", message: "" });
@@ -32,12 +32,11 @@ export function ContactForm() {
     }
     setErrors({});
     const { serviceId, templateId, userId } = getEmailJsEnv()
-    if (!serviceId || !templateId || !userId) {
-      console.error('Missing EmailJS environment variables.')
-      show(
-        'Email service is not configured properly.',
-        'error',
-      )
+    try {
+      validateEmailJsEnv()
+    } catch (err) {
+      console.error((err as Error).message)
+      show('Email service is not configured properly.', 'error')
       setStatus('ERROR')
       return
     }

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -1,4 +1,4 @@
-import { getEmailJsEnv } from '../env';
+import { getEmailJsEnv, validateEmailJsEnv } from '../env';
 
 describe('getEmailJsEnv', () => {
   const originalEnv = process.env;
@@ -28,5 +28,21 @@ describe('getEmailJsEnv', () => {
       templateId: undefined,
       userId: undefined,
     });
+  });
+
+  it('throws when required variables are missing', () => {
+    delete process.env.EMAILJS_SERVICE_ID;
+    delete process.env.EMAILJS_TEMPLATE_ID;
+    delete process.env.EMAILJS_USER_ID;
+    expect(() => validateEmailJsEnv()).toThrow(
+      'Missing EmailJS environment variables: EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, EMAILJS_USER_ID',
+    );
+  });
+
+  it('does not throw when all variables exist', () => {
+    process.env.EMAILJS_SERVICE_ID = 'svc';
+    process.env.EMAILJS_TEMPLATE_ID = 'tpl';
+    process.env.EMAILJS_USER_ID = 'uid';
+    expect(() => validateEmailJsEnv()).not.toThrow();
   });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -9,6 +9,23 @@ export function getEmailJsEnv() {
   }
 }
 
+export function validateEmailJsEnv() {
+  const { serviceId, templateId, userId } = getEmailJsEnv()
+  const missing: string[] = []
+  if (!serviceId || serviceId === 'default_service_id' || serviceId === 'placeholder') {
+    missing.push('EMAILJS_SERVICE_ID')
+  }
+  if (!templateId || templateId === 'default_template_id' || templateId === 'placeholder') {
+    missing.push('EMAILJS_TEMPLATE_ID')
+  }
+  if (!userId || userId === 'default_user_id' || userId === 'placeholder') {
+    missing.push('EMAILJS_USER_ID')
+  }
+  if (missing.length) {
+    throw new Error(`Missing EmailJS environment variables: ${missing.join(', ')}`)
+  }
+}
+
 export function getGoogleAnalyticsId() {
   return process.env.NEXT_PUBLIC_GA_ID
 }


### PR DESCRIPTION
## Summary
- validate EmailJS env vars in `src/lib/env.ts`
- use `validateEmailJsEnv` in `ContactForm`
- cover new validation with unit tests
- document change in Changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e39425b08832a9f2c8e32804b6aeb