### PR TITLE
Fix EmailJS secrets usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   check-secrets:
     runs-on: ubuntu-latest
     env:
-      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID || 'default_service_id' }}
-      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID || 'default_template_id' }}
-      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID || 'default_user_id' }}
+      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
+      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
+      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
     steps:
       - name: Debug Secrets
         run: |
@@ -36,10 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # EmailJS credentials should be configured as GitHub Secrets.
-      # CI will fail if these values remain as the fallback 'placeholder'.
-      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID || 'placeholder' }}
-      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID || 'placeholder' }}
-      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID || 'placeholder' }}
+      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
+      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
+      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -545,3 +545,6 @@ myportfolio/
   - Added CI job step to log EmailJS secrets for troubleshooting
   - Explained secret creation process in README
 
+- 2025-08-10 (Codex) - CI workflow now strictly requires EmailJS secrets
+  - Removed placeholder defaults from ci.yml
+  - Secrets must be set in GitHub settings for the workflow to pass


### PR DESCRIPTION
## Summary
- use GitHub secrets directly in the CI workflow
- document need for real EmailJS secrets in the changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e41b63e8c832a86dad273b8446e81