### PR TITLE
Fix EmailJS env validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,3 +548,6 @@ myportfolio/
 - 2025-08-10 (Codex) - CI workflow now strictly requires EmailJS secrets
   - Removed placeholder defaults from ci.yml
   - Secrets must be set in GitHub settings for the workflow to pass
+- 2025-08-11 (Codex) - EmailJS env validation in Next config
+  - next.config.ts validates EmailJS variables on load
+  - ContactForm uses non-null assertions for emailjs.send

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 import path from "path";
 import createNextIntlPlugin from 'next-intl/plugin';
+import { validateEmailJsEnv } from './src/lib/env';
+
+validateEmailJsEnv();
 
 const withNextIntl = createNextIntlPlugin('./next-intl.config.js');
 

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -43,14 +43,14 @@ export function ContactForm() {
     start();
     try {
       await emailjs.send(
-        serviceId,
-        templateId,
+        serviceId!,
+        templateId!,
         {
           from_name: form.name,
           reply_to: form.email,
           message: form.message,
         },
-        userId
+        userId!
       );
       setStatus("SUCCESS");
       setForm({ name: "", email: "", message: "" });


### PR DESCRIPTION
## Summary
- ensure EmailJS vars are validated when Next config loads
- assert EmailJS vars in `ContactForm`
- document update in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e470b7290832ab09cbf58ad5becd9