### PR TITLE
Fix CI secrets prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           [[ -z "$EMAILJS_USER_ID" || "$EMAILJS_USER_ID" == 'default_user_id' ]] && missing+=("EMAILJS_USER_ID: Not Set")
           if [ ${#missing[@]} -ne 0 ]; then
             echo "::error::Missing secrets: ${missing[*]}"
+            echo "Please add them in GitHub repository Settings > Secrets and variables > Actions."
             exit 1
           fi
           echo "EmailJS secrets are correctly configured."

--- a/README.md
+++ b/README.md
@@ -554,3 +554,5 @@ myportfolio/
   - ContactForm uses non-null assertions for emailjs.send
 - 2025-08-12 (Codex) - Local script for EmailJS secrets validation
   - Added `scripts/checkEmailJsSecrets.ts` and `npm run check:secrets`
+- 2025-08-13 (Codex) - CI secrets check instructions improved
+  - `check-secrets` job now prompts to add EmailJS values via Settings > Secrets and variables > Actions


### PR DESCRIPTION
## Summary
- improve `check-secrets` CI job to give instructions when EmailJS secrets are missing
- document the CI update in the Changelog

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e53bca9d4832a966c83ba80f45bac