### PR TITLE
Fix CI env mapping for EmailJS secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
     branches: ["main"]
 
+env:
+  EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
+  EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
+  EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
+
 jobs:
   check-secrets:
     runs-on: ubuntu-latest
-    env:
-      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
-      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
-      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,11 +25,6 @@ jobs:
   build:
     needs: check-secrets
     runs-on: ubuntu-latest
-    env:
-      # EmailJS credentials should be configured as GitHub Secrets.
-      EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
-      EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
-      EMAILJS_USER_ID: ${{ secrets.EMAILJS_USER_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -570,3 +570,5 @@ myportfolio/
   - Local and CI secret validation logic now share the same script
 - 2025-08-15 (Codex) - EmailJS secrets auto check enhancement
   - `scripts/checkEmailJsSecrets.ts` outputs missing variables in friendly format and fails the build if any are absent
+- 2025-08-16 (Codex) - CI workflow secret env centralization
+  - Moved EmailJS secret mapping to top-level `env` in ci.yml


### PR DESCRIPTION
## Summary
- simplify `ci.yml` secrets by moving them to workflow-level env
- document EmailJS env changes in Changelog

## Testing
- `EMAILJS_SERVICE_ID=dummy EMAILJS_TEMPLATE_ID=dummy EMAILJS_USER_ID=dummy npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ee2ae58f0832a89bf9ca18fcfff5b