### PR TITLE
Add debug step for EmailJS secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           node-version: 20
       - run: npm ci --prefer-offline --no-audit --progress=false
+      - name: Display EmailJS secret status
+        run: |
+          echo "EMAILJS_SERVICE_ID: ${EMAILJS_SERVICE_ID:-Not Set}"
+          echo "EMAILJS_TEMPLATE_ID: ${EMAILJS_TEMPLATE_ID:-Not Set}"
+          echo "EMAILJS_USER_ID: ${EMAILJS_USER_ID:-Not Set}"
       - run: npm run check:secrets
 
   build:

--- a/README.md
+++ b/README.md
@@ -572,3 +572,5 @@ myportfolio/
   - `scripts/checkEmailJsSecrets.ts` outputs missing variables in friendly format and fails the build if any are absent
 - 2025-08-16 (Codex) - CI workflow secret env centralization
   - Moved EmailJS secret mapping to top-level `env` in ci.yml
+- 2025-08-17 (Codex) - CI secrets debug step added
+  - check-secrets job now prints EmailJS secret status before validation


### PR DESCRIPTION
## Summary
- show secret status in CI workflow before checks
- document the new debug step in Changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef1114e4c832abf97ec7258412256