### PR TITLE
Add env-based contact email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 EMAILJS_SERVICE_ID=<your-service-id>
 EMAILJS_TEMPLATE_ID=<your-template-id>
 EMAILJS_USER_ID=<your-user-id>
+NEXT_PUBLIC_CONTACT_EMAIL=contact@example.com
 NEXT_PUBLIC_GA_ID=
 BLOG_RSS_URL=
 GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 > - `EMAILJS_TEMPLATE_ID`: EmailJS 템플릿 ID
 > - `EMAILJS_USER_ID`: EmailJS 사용자 ID
 > - `OFFLINE_MODE`: `npm run generate:resume` 실행 시 `true`로 설정하면 폰트 다운로드를 시도하지 않습니다.
+> - `NEXT_PUBLIC_CONTACT_EMAIL`: Contact 페이지에 표시할 이메일 주소
 
 ### EmailJS 시크릿 설정
 
@@ -575,3 +576,6 @@ myportfolio/
 - 2025-08-18 (Codex) - Removed login page and email authentication
   - Deleted /login route, LoginForm component, and related tests
   - Header navigation no longer includes a login link
+- 2025-08-19 (Codex) - Contact page email address via env variable
+  - Added `NEXT_PUBLIC_CONTACT_EMAIL` entry in `.env.example`
+  - Contact page reads email from this variable

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,6 +1,7 @@
 import { ContactForm } from "@/components/ContactForm";
 import ResumeDownloadLink from "@/components/ResumeDownloadLink";
 import { getTranslations } from "next-intl/server";
+import { getContactEmail } from "@/lib/env";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -23,6 +24,7 @@ export const metadata = {
 export default async function ContactPage({ params }: PageProps) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'contact' });
+  const email = getContactEmail() ?? 'contact@example.com';
   return (
     <main id="main-content" className="mx-auto w-full max-w-5xl p-8 sm:p-20">
       <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{t('title')}</h1>
@@ -32,7 +34,7 @@ export default async function ContactPage({ params }: PageProps) {
           Contact Info
         </h2>
           <p className="text-lg text-gray-700 dark:text-gray-300">
-            {t('email')}: <a href="mailto:contact@saeil.dev" className="text-blue-600 dark:text-blue-400 hover:underline">contact@saeil.dev</a>
+            {t('email')}: <a href={`mailto:${email}`} className="text-blue-600 dark:text-blue-400 hover:underline">{email}</a>
           </p>
           <p className="text-lg text-gray-700 dark:text-gray-300">
             {t('github')}: <a href="https://github.com/saeil" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">github.com/saeil</a>

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -45,3 +45,7 @@ export function getBlogRssUrl() {
   }
   return BLOG_RSS_URL
 }
+
+export function getContactEmail() {
+  return process.env.NEXT_PUBLIC_CONTACT_EMAIL
+}


### PR DESCRIPTION
## Summary
- load contact email from `NEXT_PUBLIC_CONTACT_EMAIL`
- show this email in contact page
- document new variable in README
- example value in `.env.example`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684efe5fe188832aa5dd51d8f07d4858