### PR TITLE
Fix PageProps types for Next.js 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,25 @@ PR 생성 전 다음 명령어로 전체 소스에서 충돌 마커를 검색하
 grep -R "<<<<<<<" -n
 ```
 
+### App Router 페이지 타입 가이드
+
+Next.js 15부터는 App Router의 `PageProps`가 비동기 형태로 전달됩니다. `params`
+와 `searchParams` 모두 `Promise` 타입이므로 아래와 같이 `await`해 사용하세요.
+
+```ts
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function Page({ params }: PageProps) {
+  const { locale } = await params;
+  // ...
+}
+```
+
+`searchParams` 사용 시에도 동일하게 `const query = await searchParams;` 형태로
+작성하면 빌드 타임 타입 오류를 방지할 수 있습니다.
+
 ---
 
 ## 📌 주요 기능 및 UI 구성 요약
@@ -641,3 +660,7 @@ pgqpkx-codex/emailjs-환경-변수-체크-스크립트-개선
   - `[locale]/about`, `[locale]/contact`, `[locale]/projects` 하위 페이지의 `PageProps`
     타입에서 `Promise` 제거
   - Vercel 빌드 시 `TypeError: e is not a function` 오류가 발생하던 문제 해결
+- 2025-08-27 (Codex) - Next.js 15 대응 PageProps 수정
+  - Next.js 15의 App Router 타입 업데이트에 맞춰 `PageProps`의 `params`와
+    `searchParams`를 `Promise` 타입으로 재정의
+  - about, contact, projects 관련 페이지 함수 시그니처 수정 및 ESLint/테스트 통과 확인

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -4,7 +4,7 @@ import type { TimelineEntry } from "@/data/types";
 import timelineData from "../../../../content/about/timeline.json";
 
 interface PageProps {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }
 
 export const metadata = {
@@ -24,7 +24,7 @@ export const metadata = {
 const timeline: TimelineEntry[] = timelineData;
 
 export default async function AboutPage({ params }: PageProps) {
-  const { locale } = params;
+  const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'about' });
   return (
     <main id="main-content" className="mx-auto w-full max-w-5xl space-y-16 p-8 sm:p-20">

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -4,7 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { getContactEmail } from "@/lib/env";
 
 interface PageProps {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }
 
 export const metadata = {
@@ -22,7 +22,7 @@ export const metadata = {
 };
 
 export default async function ContactPage({ params }: PageProps) {
-  const { locale } = params;
+  const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'contact' });
   const email = getContactEmail() ?? 'contact@example.com';
   return (

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -6,11 +6,11 @@ import type { JSX } from "react";
 import type { Metadata } from "next";
 
 interface PageProps {
-  params: { slug: string | string[] | undefined; locale: string };
+  params: Promise<{ slug: string | string[] | undefined; locale: string }>;
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { slug } = params;
+  const { slug } = await params;
   const slugValue = Array.isArray(slug) ? slug[0] : slug;
   const projects = await getProjects();
   const project = projects.find((p) => p.slug === slugValue);
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 export default async function Page({ params }: PageProps): Promise<JSX.Element> {
-  const { slug, locale } = params;
+  const { slug, locale } = await params;
   const slugValue = Array.isArray(slug) ? slug[0] : slug;
   const projects = await getProjects();
   const project = projects.find((p) => p.slug === slugValue);

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -5,7 +5,7 @@ import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
 interface PageProps {
-  searchParams: Record<string, string | string[] | undefined>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export const metadata: Metadata = {
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ProjectsPage({ searchParams }: PageProps) {
-  const params = searchParams;
+  const params = await searchParams;
   const projects = await getProjects();
   const stackParam = Array.isArray(params.stack) ? params.stack[0] : params.stack;
   const yearParam = Array.isArray(params.year) ? params.year[0] : params.year;


### PR DESCRIPTION
## Summary
- adjust PageProps in dynamic pages to match Next.js 15 async params
- update README with App Router PageProps guide and changelog entry

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: TypeError: e is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_685001b367e0832aa285ffe3ae303951