### PR TITLE
Fix PageProps for Next.js 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,31 @@ myportfolio/
 | 2025-06-15 | i18n 및 기능 개선: 다국어 라우팅, GitHub 통계 안내 개선, PDF 이력서 확장, 컴포넌트 테스트 확대 |
 | 2025-06-16 | UI/로직 품질 및 국제화 개선: BlogSection·ProjectFilterBar 테스트, 로케일 스위처, 전 페이지 다국어화, 이력서 스크립트 TS 전환 |
 
+### 2025-06-17
+
+| 날짜 | 주요 변경 사항 |
+| --- | --- |
+| 2025-06-17 | App Router 비동기 params 타입 적용 및 README 가이드 추가 |
+
 ### 다국어 전환 방법
 기본 언어는 한국어이며 `/en` 경로로 접속하면 영어 페이지가 제공됩니다. 예) `/en/projects`.
+
+### App Router 비동기 params 사용 가이드
+Next.js 15부터 `params`와 `searchParams`가 비동기 프라미스로 전달됩니다.
+페이지 컴포넌트에서는 다음과 같이 `await` 키워드를 사용하여 값을 추출해야
+합니다.
+
+```tsx
+interface PageProps {
+  params: Promise<{ locale: string }>
+}
+
+export default async function AboutPage({ params }: PageProps) {
+  const { locale } = await params
+  // ...
+}
+```
+
+타입 오류를 방지하기 위해 제너레이트된 타입 정의를 참고하여 위와 같이
+프라미스 형태로 선언하는 것을 권장합니다.
 

--- a/scripts/printChangelogSummary.ts
+++ b/scripts/printChangelogSummary.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs'
 
 function printSummary() {
   const readme = readFileSync('README.md', 'utf8')
-  const match = readme.match(/### 패치 내역 요약.*?(?:\n\|.*)+/s)
+  const match = readme.match(/### 패치 내역 요약[\s\S]*?(?:\n\|.*)+/)
   if (match) {
     console.log(match[0].trim())
   } else {

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -4,7 +4,7 @@ import type { TimelineEntry } from "@/data/types";
 import timelineData from "../../../../content/about/timeline.json";
 
 interface PageProps {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }
 
 export const metadata = {
@@ -24,7 +24,7 @@ export const metadata = {
 const timeline: TimelineEntry[] = timelineData;
 
 export default async function AboutPage({ params }: PageProps) {
-  const { locale } = params;
+  const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'about' });
   return (
     <main id="main-content" className="mx-auto w-full max-w-5xl space-y-16 p-8 sm:p-20">

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -4,7 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { getContactEmail } from "@/lib/env";
 
 interface PageProps {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }
 
 export const metadata = {
@@ -22,7 +22,7 @@ export const metadata = {
 };
 
 export default async function ContactPage({ params }: PageProps) {
-  const { locale } = params;
+  const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'contact' });
   const email = getContactEmail() ?? 'contact@example.com';
   return (

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -6,11 +6,11 @@ import type { JSX } from "react";
 import type { Metadata } from "next";
 
 interface PageProps {
-  params: { slug: string | string[] | undefined; locale: string };
+  params: Promise<{ slug: string | string[] | undefined; locale: string }>;
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { slug } = params;
+  const { slug } = await params;
   const slugValue = Array.isArray(slug) ? slug[0] : slug;
   const projects = await getProjects();
   const project = projects.find((p) => p.slug === slugValue);
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 export default async function Page({ params }: PageProps): Promise<JSX.Element> {
-  const { slug, locale } = params;
+  const { slug, locale } = await params;
   const slugValue = Array.isArray(slug) ? slug[0] : slug;
   const projects = await getProjects();
   const project = projects.find((p) => p.slug === slugValue);

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -5,7 +5,7 @@ import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
 interface PageProps {
-  searchParams: Record<string, string | string[] | undefined>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export const metadata: Metadata = {
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ProjectsPage({ searchParams }: PageProps) {
-  const params = searchParams;
+  const params = await searchParams;
   const projects = await getProjects();
   const stackParam = Array.isArray(params.stack) ? params.stack[0] : params.stack;
   const yearParam = Array.isArray(params.year) ? params.year[0] : params.year;


### PR DESCRIPTION
## Summary
- fix PageProps declarations for About, Contact, and Projects pages
- update script regex to avoid es2018 flag
- document async params handling in README

## Testing
- `npm run lint`
- `npm run build` *(fails: TypeError during page prerendering)*

------
https://chatgpt.com/codex/tasks/task_e_685035051c6c832aa8183ad7effd734c