### PR TITLE
Add optional skip for missing EmailJS secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
           echo "EMAILJS_SERVICE_ID: ${EMAILJS_SERVICE_ID:-Not Set}"
           echo "EMAILJS_TEMPLATE_ID: ${EMAILJS_TEMPLATE_ID:-Not Set}"
           echo "EMAILJS_USER_ID: ${EMAILJS_USER_ID:-Not Set}"
+      - name: Skip secret check if variables are missing
+        run: |
+          missing=false
+          [ -z "$EMAILJS_SERVICE_ID" ] && missing=true
+          [ -z "$EMAILJS_TEMPLATE_ID" ] && missing=true
+          [ -z "$EMAILJS_USER_ID" ] && missing=true
+          if [ "$missing" = true ]; then
+            echo "ALLOW_MISSING_EMAILJS_SECRETS=true" >> "$GITHUB_ENV"
+          fi
       - run: npm run check:secrets
 
   build:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 >   - 프로덕션 빌드에서는 위 값들이 모두 필요하며, 누락 시 오류로 처리됩니다.
 > - `OFFLINE_MODE`: `npm run generate:resume` 실행 시 `true`로 설정하면 폰트 다운로드를 시도하지 않습니다.
 > - `NEXT_PUBLIC_CONTACT_EMAIL`: Contact 페이지에 표시할 이메일 주소
+> - `ALLOW_MISSING_EMAILJS_SECRETS`: CI에서 값이 없을 때 검사를 건너뜁니다.
 
 ### GitHub Actions EmailJS Secret 등록
 
@@ -449,6 +450,12 @@ myportfolio/
 | 날짜 | 주요 변경 사항 |
 | --- | --- |
 | 2025-06-22 | `prebuild` 단계에 EmailJS 시크릿 검사를 추가하여 누락 시 빌드가 실패하도록 개선 |
+
+### 2025-06-23
+
+| 날짜 | 주요 변경 사항 |
+| --- | --- |
+| 2025-06-23 | `ALLOW_MISSING_EMAILJS_SECRETS` 변수로 CI 시크릿 검사를 선택적으로 건너뜀 |
 
 ### 다국어 전환 방법
 기본 언어는 한국어이며 `/en` 경로로 접속하면 영어 페이지가 제공됩니다. 예) `/en/projects`.

--- a/scripts/checkEmailJsSecrets.ts
+++ b/scripts/checkEmailJsSecrets.ts
@@ -1,5 +1,12 @@
 import { getEmailJsEnv } from '../src/lib/env'
 
+if (process.env.ALLOW_MISSING_EMAILJS_SECRETS === 'true') {
+  console.log(
+    'ALLOW_MISSING_EMAILJS_SECRETS is set. Skipping EmailJS secret check.',
+  )
+  process.exit(0)
+}
+
 function checkEmailJsSecrets() {
   const { serviceId, templateId, userId } = getEmailJsEnv()
   const variables = [


### PR DESCRIPTION
## Summary
- allow skipping EmailJS secret check with `ALLOW_MISSING_EMAILJS_SECRETS`
- skip secret check step in CI when secrets are absent
- document new env var

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852ef9bfdbc832ab65fbec81c31f67f